### PR TITLE
docs: Add state machine documentation to ways system

### DIFF
--- a/hooks/ways/check-bash-post.sh
+++ b/hooks/ways/check-bash-post.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 # PostToolUse: Check bash commands against way frontmatter
+#
+# TRIGGER FLOW:
+# ┌──────────────────┐     ┌─────────────────┐     ┌──────────────┐
+# │ PostToolUse:Bash │────▶│ scan_ways()     │────▶│ show-way.sh  │
+# │ (hook event)     │     │ for each *.md:  │     │ (idempotent) │
+# └──────────────────┘     │  if commands OR │     └──────────────┘
+#                          │  keywords match │
+#                          └─────────────────┘
+#
+# Multiple ways can match a single command - CONTEXT accumulates
+# all matching way outputs. Markers prevent duplicate content.
+# Output is returned as additionalContext JSON for Claude to see.
 
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')

--- a/hooks/ways/check-file-post.sh
+++ b/hooks/ways/check-file-post.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 # PostToolUse: Check file operations against way frontmatter
+#
+# TRIGGER FLOW:
+# ┌───────────────────────┐     ┌─────────────────┐     ┌──────────────┐
+# │ PostToolUse:Edit/Write│────▶│ scan_ways()     │────▶│ show-way.sh  │
+# │ (hook event)          │     │ for each *.md:  │     │ (idempotent) │
+# └───────────────────────┘     │  if files match │     └──────────────┘
+#                               └─────────────────┘
+#
+# Multiple ways can match a single file path - CONTEXT accumulates
+# all matching way outputs. Markers prevent duplicate content.
+# Output is returned as additionalContext JSON for Claude to see.
 
 INPUT=$(cat)
 FP=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')

--- a/hooks/ways/check-prompt.sh
+++ b/hooks/ways/check-prompt.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 # Check user prompts for keywords from way frontmatter
+#
+# TRIGGER FLOW:
+# ┌──────────────────┐     ┌─────────────────┐     ┌──────────────┐
+# │ UserPromptSubmit │────▶│ scan_ways()     │────▶│ show-way.sh  │
+# │ (hook event)     │     │ for each *.md:  │     │ (idempotent) │
+# └──────────────────┘     │  if keywords    │     └──────────────┘
+#                          │  match prompt   │
+#                          └─────────────────┘
+#
+# Multiple ways can match a single prompt - each way's show-way.sh
+# is called, but markers prevent duplicate output within session.
+# Project-local ways are scanned first (and take precedence).
 
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' | tr '[:upper:]' '[:lower:]')

--- a/hooks/ways/knowledge.md
+++ b/hooks/ways/knowledge.md
@@ -60,3 +60,24 @@ Project ways take precedence over global ways with same name.
 - Global: `~/.claude/hooks/ways/`
 - Project: `$PROJECT/.claude/ways/`
 - Markers: `/tmp/.claude-way-{name}-{session_id}`
+
+## State Machine
+
+Each (way, session) pair has two states:
+
+```
+┌─────────────┐   keyword/command/file match   ┌─────────────┐
+│  not_shown  │ ─────────────────────────────▶ │   shown     │
+│  (no marker)│        output + create marker  │(marker exists)
+└─────────────┘                                └─────────────┘
+       │                                              │
+       │         any subsequent match                 │
+       │◀─────────────────────────────────────────────│
+                     no-op (idempotent)
+```
+
+**Multi-trigger semantics:**
+- Single prompt may match multiple ways → all fire (each has own marker)
+- Same way matched multiple times → first wins, rest are no-ops
+- Multiple hooks (prompt, bash, file) may fire same way → marker prevents duplicates
+- Project-local and global with same name → project-local wins (single marker per name)

--- a/hooks/ways/show-way.sh
+++ b/hooks/ways/show-way.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 # Show a "way" once per session (strips frontmatter)
 # Usage: show-way.sh <way-name> <session-id>
+#
+# STATE MACHINE:
+# ┌─────────────────┬────────────────────────────────────┐
+# │ Marker State    │ Action                             │
+# ├─────────────────┼────────────────────────────────────┤
+# │ not exists      │ output way, create marker          │
+# │ exists          │ no-op (idempotent)                 │
+# └─────────────────┴────────────────────────────────────┘
+#
+# This script is called by multiple hooks (check-prompt.sh,
+# check-bash-post.sh, check-file-post.sh). It may be called
+# multiple times for the same way in a single event cycle.
+# The marker file ensures idempotency - first call wins.
+#
+# Marker: /tmp/.claude-way-{wayname}-{session_id}
 
 WAY="$1"
 SESSION_ID="$2"


### PR DESCRIPTION
## Summary

Adds documentation explaining the ways system's state machine and multi-trigger semantics.

## Changes

- **show-way.sh**: Added state machine diagram showing idempotency guarantees
- **check-prompt.sh**: Added trigger flow diagram
- **check-bash-post.sh**: Added trigger flow diagram  
- **check-file-post.sh**: Added trigger flow diagram
- **knowledge.md**: Added full state machine section with multi-trigger semantics

## Why This Matters

The ways system can receive multiple trigger events for the same way (e.g., prompt matches + command matches). This documents that:

1. Multiple different ways CAN fire from one event (each has own marker)
2. Same way matched multiple times → first wins, rest are no-ops
3. Marker files ensure idempotency across all hook types

## Test Plan

- [x] Verify documentation is accurate by reading existing code
- [x] Test multiple ways firing on single prompt
- [x] Test same way triggered by prompt then command (should only show once)