### PR TITLE
feat: docs way enhancements and introspection meta-way

### DIFF
--- a/hooks/ways/meta/introspection/way.md
+++ b/hooks/ways/meta/introspection/way.md
@@ -1,0 +1,85 @@
+---
+match: regex
+pattern: pull.?request|create.*pr|pr.*create|write.*pr|open.*pr
+commands: gh\ pr\ create
+scope: agent
+---
+# Introspection Way
+
+A pull request is a natural boundary of work — a moment to pause and reflect before closing the loop. Regardless of what the PR contains (code, config, docs, process), this is the right time to ask: did we learn something this session that should become a way?
+
+## Two-Part Flow
+
+This introspection splits between you (the main agent) and a subagent. You hold the session history — only you can identify what the human taught. The subagent gets a fresh context window to review existing ways and draft proposals without burning your remaining tokens.
+
+### Part 1: You Summarize (main agent)
+
+Before creating the PR, look back through this conversation for moments where the human:
+- **Corrected** something — "No, we do it this way..."
+- **Explained** a convention — "The reason we X is because Y..."
+- **Guided** a choice — "We prefer A over B here because..."
+- **Pushed back** — "That's not how this project works..."
+- **Repeated** a preference — if they said it twice, it's a pattern
+
+Compile a concise summary of these signals. For each one, capture:
+- **What** the human said or corrected
+- **Why** they said it (if they gave a reason)
+- **When** it would apply again (what kind of work would hit this)
+
+If you find nothing — no corrections, no explanations, no guidance — that's a valid outcome. Say so and skip the subagent.
+
+### Part 2: Subagent Reviews Ways and Proposes
+
+Spawn a subagent (`subagent_type: "general-purpose"`) with:
+1. Your summary of human signals from Part 1
+2. The project path so it can find `$PROJECT/.claude/ways/`
+3. Instructions to follow the review process below
+
+**Subagent prompt template:**
+
+> Review project-local ways and propose new ones based on session learnings.
+>
+> **Project path:** [path]
+>
+> **Session signals from human:**
+> [your summary from Part 1]
+>
+> **Your tasks:**
+>
+> 1. **Enumerate existing project-local ways** — list what's in `$PROJECT/.claude/ways/`. Note if none exist.
+>
+> 2. **Check for overlap** — do any existing ways already cover the signals above? If so, note whether they need updating or are sufficient.
+>
+> 3. **Propose new ways** for uncovered signals. For each proposal, specify:
+>    - File path: `$PROJECT/.claude/ways/{domain}/{topic}/way.md`
+>    - Trigger type and pattern (keyword, command, or file pattern)
+>    - A draft of the way content in collaborative voice
+>
+> 4. **Skip anything that's:**
+>    - A one-off decision that won't recur
+>    - Already covered by an existing way (global or project-local)
+>    - So specific it applies to exactly one file
+>
+> Follow the Knowledge Way format: YAML frontmatter with match/pattern/files/commands, then concise guidance written as a collaborator, not a directive. Place ways in project scope.
+>
+> Return: a summary of existing ways, and any proposed new ways with their full content. Do NOT create the files — just return the proposals.
+
+### Part 3: Present to the Human
+
+Take the subagent's proposals and present them. Don't silently create ways.
+
+> "During this session, you [corrected/explained/guided] me about [X]. I had a subagent review our project ways — here's what it found and proposes:
+>
+> **Existing ways:** [list or "none yet"]
+>
+> **Proposed new ways:**
+> - `project/domain/topic/way.md` — triggered by [pattern], covering [what]
+> - ...
+>
+> Want me to create any of these?"
+
+Let the human decide what's worth keeping. Their judgment about what's a real convention vs. a one-time choice is better than yours.
+
+## Why This Matters
+
+Every session starts cold. The agent that arrives next has no memory of corrections made today. If a convention lives only in the conversation history, it dies when the session ends. Ways are how we carry forward what the human teaches us.

--- a/hooks/ways/softwaredev/docs/way.md
+++ b/hooks/ways/softwaredev/docs/way.md
@@ -1,10 +1,12 @@
 ---
 match: regex
-pattern: readme|documentation|docs|document.*project|explain.*repo
+pattern: readme|documentation|docs|document.*project|explain.*repo|docstring|mermaid|diagram
 files: README\.md$|docs/.*\.md$
 scope: agent, subagent
 ---
 # Documentation Way
+
+We write documentation in markdown, use language-appropriate docstrings in code, and use Mermaid for diagrams. These aren't arbitrary choices — markdown renders everywhere, docstrings live with the code they describe, and Mermaid diagrams are version-controllable text that renders in GitHub, VS Code, and most documentation tooling.
 
 ## README Philosophy
 
@@ -55,6 +57,96 @@ docs/
 └── reference/
     └── api.md
 ```
+
+## Docstrings
+
+We use docstrings in every language, following the idiomatic style for that language:
+
+| Language | Style | Example |
+|----------|-------|---------|
+| Python | Google-style docstrings | `"""Summary.\n\nArgs:\n    param: Description.\n"""` |
+| JavaScript/TypeScript | JSDoc | `/** @param {string} name - Description */` |
+| Rust | Doc comments | `/// Summary of the function.` |
+| Go | Godoc | `// FunctionName does X.` |
+| Shell/Bash | Header comment block | `# Description of what this script does` |
+
+**When to write docstrings:**
+- Public APIs, exported functions, classes, modules — always
+- Complex internal logic where intent isn't obvious from the name
+- Not needed for trivial getters, one-line helpers, or self-evident code
+
+## Diagrams — Mermaid, Not ASCII
+
+In docs files, we use Mermaid diagrams instead of ASCII art. Mermaid is diffable, renderable, and doesn't break when you need to add a box in the middle.
+
+**Choose the right diagram type for the content:**
+
+| Content | Diagram Type | Not |
+|---------|-------------|-----|
+| Temporal sequences, request/response flows | `sequenceDiagram` | flowchart |
+| State transitions, lifecycles | `stateDiagram-v2` | flowchart |
+| Decision logic, branching paths | `flowchart` | sequence |
+| Class/entity relationships | `classDiagram` | flowchart |
+| Timelines, project phases | `gantt` or `timeline` | flowchart |
+| Git branching strategies | `gitgraph` | flowchart |
+
+The most common mistake is using flowchart for everything. If the content has a time axis, it's a sequence diagram. If things transition between states, it's a state diagram.
+
+## Mermaid Styling
+
+We want diagrams that are legible in both dark and light mode contexts, with good color saturation to help readers differentiate processes and concerns.
+
+**Color principles:**
+- Use **mid-saturation colors** — vivid enough to differentiate, not so bright they strain
+- Avoid pure white (`#fff`) or pure black (`#000`) fills — they break in one mode or the other
+- Use **consistent text colors** that contrast against their fill in both modes
+
+**Recommended palette for fills and styling:**
+
+```
+Concern separation colors (good contrast, mid-saturation):
+  #2D7D9A  — teal/process blue
+  #7B2D8E  — purple/integration
+  #2D8E5E  — green/success/data
+  #C2572A  — burnt orange/warning/external
+  #5A6ABF  — slate blue/internal
+  #8E6B2D  — amber/config/state
+
+Text on colored fills:
+  #FFFFFF  — white text on darker fills above
+  #1A1A2E  — dark text on lighter fills if needed
+
+Borders:
+  #4A5568  — neutral gray, works both modes
+```
+
+**Example with styling:**
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API Gateway
+    participant S as Service
+
+    rect rgba(45, 125, 154, 0.15)
+        Note over C,A: Request Phase
+        C->>A: POST /resource
+        A->>A: Validate & auth
+    end
+
+    rect rgba(45, 142, 94, 0.15)
+        Note over A,S: Processing Phase
+        A->>S: Forward request
+        S-->>A: Response
+    end
+
+    A-->>C: 201 Created
+```
+
+**Avoid:**
+- Default unstyled diagrams when 3+ actors or concerns are present — add color to help the reader
+- Neon or pastel fills that disappear against white or dark backgrounds
+- Text-on-fill combinations that require squinting
 
 ## Principles
 


### PR DESCRIPTION
## Summary
- **Documentation way** enhanced with docstring guidance (per-language idiomatic styles), Mermaid diagram type selection (sequence vs state vs flowchart), and a mid-saturation color palette designed for dark/light mode legibility
- **Introspection way** (new) fires at PR creation as a natural work boundary — main agent summarizes human corrections/guidance from the session, delegates ways review to a subagent to preserve main context window
- Introspection uses **dual triggers**: `pattern:` on UserPromptSubmit (high-visibility system-reminder) + `commands:` on PreToolUse:Bash as backstop — whichever fires first creates the marker, second is a no-op

## Test plan
- [ ] Verify docs way triggers on `docstring`, `mermaid`, `diagram` keywords in addition to existing triggers
- [ ] Verify introspection way fires via UserPromptSubmit when user says "create a PR", "write a PR", etc.
- [ ] Verify introspection way fires via PreToolUse when `gh pr create` runs (backstop path)
- [ ] Confirm introspection way does NOT fire for subagents (`scope: agent` only)
- [ ] Test that the subagent delegation pattern works: main summarizes, subagent reviews ways and returns proposals