### PR TITLE
feat(ways): scaffolding wizard and /ways-tests rename (ADR-100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ After creating or tuning a way, verify it matches what you expect — and doesn'
 
 ```bash
 # Quick check: score a prompt against all semantic ways
-/test-way "write some unit tests for this module"
+/ways-tests "write some unit tests for this module"
 
 # Automated: BM25 vs NCD against synthetic corpus (32 tests)
 tests/way-match/run-tests.sh fixture --verbose

--- a/commands/ways-tests.md
+++ b/commands/ways-tests.md
@@ -1,43 +1,43 @@
 ---
-description: Test way matching scores and suggest vocabulary improvements
+description: Score way matching, analyze vocabulary, and validate frontmatter
 ---
 
-# test-way: Way Authoring Tool
+# ways-tests: Way Matching & Vocabulary Tool
 
 Test how well a way matches sample prompts, or analyze its vocabulary for gaps.
 
 ## Usage
 
-The user invokes `/test-way` with one of these patterns:
+The user invokes `/ways-tests` with one of these patterns:
 
 ### Score mode: test a way against prompts
 ```
-/test-way score <path/to/way.md> "sample prompt here"
-/test-way score security "how do i hash passwords with bcrypt"
+/ways-tests score <path/to/way.md> "sample prompt here"
+/ways-tests score security "how do i hash passwords with bcrypt"
 ```
 
 ### Score all ways: rank all ways against a prompt
 ```
-/test-way score-all "sample prompt here"
+/ways-tests score-all "sample prompt here"
 ```
 
 ### Suggest mode: analyze vocabulary gaps
 ```
-/test-way suggest <path/to/way.md>
-/test-way suggest security
-/test-way suggest --all
+/ways-tests suggest <path/to/way.md>
+/ways-tests suggest security
+/ways-tests suggest --all
 ```
 
 ### Suggest + apply: update vocabulary in-place
 ```
-/test-way suggest <path/to/way.md> --apply
-/test-way suggest --all --apply
+/ways-tests suggest <path/to/way.md> --apply
+/ways-tests suggest --all --apply
 ```
 
 ### Lint mode: validate way frontmatter
 ```
-/test-way lint <path/to/way.md>
-/test-way lint --all
+/ways-tests lint <path/to/way.md>
+/ways-tests lint --all
 ```
 
 ## Implementation

--- a/commands/ways.md
+++ b/commands/ways.md
@@ -1,5 +1,183 @@
 ---
-description: Show which ways have been triggered this session
+description: Create or revise project-local ways — the scaffolding wizard for steering Claude in your project
 ---
 
-Run `~/.claude/hooks/ways/list-triggered.sh` and display the output to show which contextual guidance (ways) have been triggered during this session.
+# /ways: Way Scaffolding Wizard
+
+You are a ways workshop. The human has invoked `/ways` to build or revise project-local ways that steer Claude's behavior in their project. This session is now dedicated to that work.
+
+## Before You Start
+
+**Read these docs first** — you need the full landscape before your first question:
+
+1. Read `~/.claude/docs/hooks-and-ways/matching.md` — understand all matching modes (regex, BM25 semantic, state triggers), vocabulary design, the sparsity principle, and the IR grounding
+2. Read `~/.claude/docs/hooks-and-ways/extending.md` — understand creation flow, voice/framing guidance, progressive disclosure with sub-ways, project-local overrides
+
+Do NOT skip this step. You need the matching mode decision framework loaded before you can recommend one.
+
+## Detect Project State
+
+Before engaging the human, assess what exists:
+
+1. Check if `$CLAUDE_PROJECT_DIR` is set — if not, ask what project they want to work on
+2. Check if `.claude/ways/` exists in the project
+3. If ways exist, list them with their matching modes:
+   ```bash
+   find "$CLAUDE_PROJECT_DIR/.claude/ways" -name "way.md" 2>/dev/null
+   ```
+4. For each existing way, extract the frontmatter (pattern, description, vocabulary, trigger) and show a summary table
+
+Report what you find before asking what the human wants to do.
+
+## Interview Flow
+
+Use `AskUserQuestion` with multiple-choice options where appropriate. The interview adapts based on answers.
+
+### Entry Question
+
+If the project has no ways:
+> "This project doesn't have any ways yet. What should Claude know or do differently when working here?"
+
+If the project has existing ways:
+> Present the summary table, then ask: "Do you want to create a new way, or revise an existing one?"
+
+### For New Ways — Discover Intent
+
+Ask in plain language. Do NOT lead with technical terms like "frontmatter" or "matching mode."
+
+**What to find out through conversation:**
+- What behavior should change? ("Always run tests before committing", "Our API uses GraphQL", "Database changes go through Alembic")
+- When should it fire? Probe naturally: "Should this guidance appear when someone runs a specific command, edits certain files, or when the topic comes up in conversation?"
+- How specific or broad is the concept? This determines matching mode.
+
+**Recommend the matching mode** with a one-sentence reason:
+- "That sounds like it should fire on `git commit` — a command trigger is reliable and fast here."
+- "People could describe this many ways — semantic matching with BM25 will catch 'optimize', 'slow', 'performance' without listing every synonym."
+- "This should fire any time someone touches a migration file — a file pattern trigger is the right fit."
+
+### For Revision — Diagnose the Problem
+
+Ask what's wrong:
+- "It's not firing when it should" → check trigger patterns, test with `/ways-tests score`
+- "It fires when it shouldn't" → vocabulary overlap, check with `/ways-tests score-all`
+- "The guidance isn't helpful" → review the content, apply voice/framing principles
+- "I want to change what it covers" → may need vocabulary tuning, scope change, or split into sub-ways
+
+Use the `way-match` binary for live diagnostics:
+```bash
+~/.claude/bin/way-match pair --description "$desc" --vocabulary "$vocab" --query "$prompt" --threshold "${thresh:-2.0}"
+```
+
+## Scaffold
+
+When creating a new way:
+
+### 1. Choose domain and name
+
+If the project has existing ways, show the domains in use and suggest consistency. If it's the first way, suggest a domain that fits:
+- Project-specific patterns → use the project name as domain
+- General development practices → `dev`, `code`, or a descriptive name
+- Infrastructure/deployment → `infra`, `ops`
+
+### 2. Create the directory and file
+
+```bash
+mkdir -p "$CLAUDE_PROJECT_DIR/.claude/ways/{domain}/{wayname}"
+```
+
+### 3. Write way.md
+
+The frontmatter must match the chosen trigger strategy. The body should:
+- Be directive and concise (20-60 lines ideal)
+- Include the *why*, not just the *what*
+- Use "we" framing — collaborative, not commanding
+- Write for a reader with zero prior context (the innie)
+
+**Template for regex trigger:**
+```markdown
+---
+pattern: keyword1|keyword2|keyword3
+---
+# Way Name
+
+## Guidance
+- Directive that includes reasoning
+```
+
+**Template for semantic trigger:**
+```markdown
+---
+description: natural language description of what this way covers
+vocabulary: domain specific terms users would say in prompts
+threshold: 2.0
+---
+# Way Name
+
+## Guidance
+- Directive that includes reasoning
+```
+
+**Template for command trigger:**
+```markdown
+---
+commands: git\ commit|git\ push
+---
+# Way Name
+
+## Guidance
+- Directive that includes reasoning
+```
+
+**Template for file trigger:**
+```markdown
+---
+files: \.migration\.|alembic/|prisma/
+---
+# Way Name
+
+## Guidance
+- Directive that includes reasoning
+```
+
+### 4. Write the content collaboratively
+
+Don't generate the full way body without input. Draft it, show the human, and iterate. The human knows their project's conventions — you know the way format and voice guidelines.
+
+## Validate
+
+After creating or revising a way:
+
+1. **Lint**: Check frontmatter is valid
+   ```bash
+   # Verify the way has required fields and valid structure
+   ```
+
+2. **Score** (for semantic ways): Test against sample prompts from the conversation
+   ```bash
+   ~/.claude/bin/way-match pair --description "$desc" --vocabulary "$vocab" --query "sample prompt" --threshold 2.0
+   ```
+
+3. **Cross-check**: Score all project ways against the same prompt to verify no cross-firing
+   ```bash
+   # For each way in the project, score against the sample prompt
+   ```
+
+4. Show results and explain: match/no-match, score vs threshold, any overlaps with other ways
+
+## Handoff
+
+After the way is created or revised:
+
+- Show the file location: `.claude/ways/{domain}/{wayname}/way.md`
+- Explain when it will fire: "Next session, when you [trigger condition], this guidance will load automatically"
+- Point to `/ways-tests` for ongoing tuning: "Use `/ways-tests score {wayname} 'prompt'` to test matching, `/ways-tests suggest {wayname}` to analyze vocabulary"
+- If the way has semantic matching, suggest running `/ways-tests score-all "sample prompt"` to verify it doesn't overlap with other ways
+- Remind them the way is committed to the project repo — teammates get it too
+
+## Principles
+
+- **The human doesn't need to know the word "frontmatter"** — ask about intent, translate to implementation
+- **Recommend, don't quiz** — "I'd suggest semantic matching here because..." not "Which matching mode do you prefer?"
+- **Draft collaboratively** — show your work, get feedback, iterate
+- **The session is a workshop** — context spent on reading docs and testing is well spent
+- **Creation and revision are equal** — a human fixing a misfiring way is doing the same work as creating one

--- a/docs/architecture/system/ADR-100-ways-scaffolding-wizard.md
+++ b/docs/architecture/system/ADR-100-ways-scaffolding-wizard.md
@@ -40,7 +40,7 @@ The wizard is a Claude Code skill (`commands/ways.md`) that directs Claude throu
 
 5. **Validate**: Lint the new way. If semantic, score it against sample prompts from the conversation. Show the result.
 
-6. **Handoff**: Point to `/test-way` for ongoing tuning. Explain that the way will fire automatically in future sessions when the trigger conditions are met.
+6. **Handoff**: Point to `/ways-tests` for ongoing tuning. Explain that the way will fire automatically in future sessions when the trigger conditions are met.
 
 ### Session commitment
 

--- a/docs/hooks-and-ways.md
+++ b/docs/hooks-and-ways.md
@@ -420,8 +420,8 @@ Three test layers verify the matching and injection pipeline. See [tests/README.
 | **Integration** | `bash tools/way-match/test-integration.sh` | Real way files, frontmatter extraction, multi-way discrimination |
 | **Activation** | `read and run the activation test at tests/way-activation-test.md` | Live hook pipeline: regex, BM25, negative control, subagent injection |
 
-The `/test-way` skill provides ad-hoc scoring for vocabulary tuning:
+The `/ways-tests` skill provides ad-hoc scoring for vocabulary tuning:
 
 ```
-/test-way "write some unit tests for this module"
+/ways-tests "write some unit tests for this module"
 ```

--- a/docs/hooks-and-ways/extending.md
+++ b/docs/hooks-and-ways/extending.md
@@ -47,17 +47,17 @@ This isn't sentimental. It's functional. An agent that understands "we do this b
 
 ### Testing a way
 
-Use `/test-way` to validate matching quality without trial-and-error:
+Use `/ways-tests` to validate matching quality without trial-and-error:
 
 ```
-/test-way score <way> "sample prompt"       # test one way against a prompt
-/test-way score-all "sample prompt"         # rank all ways — check for false positives
-/test-way suggest <way>                     # find vocabulary gaps
-/test-way suggest --all                     # survey all ways at once
-/test-way lint <way>                        # validate frontmatter
+/ways-tests score <way> "sample prompt"       # test one way against a prompt
+/ways-tests score-all "sample prompt"         # rank all ways — check for false positives
+/ways-tests suggest <way>                     # find vocabulary gaps
+/ways-tests suggest --all                     # survey all ways at once
+/ways-tests lint <way>                        # validate frontmatter
 ```
 
-For semantic ways, `/test-way suggest` analyzes the way body text and recommends vocabulary additions. Not all suggestions should be added — body terms like "code" or "use" don't discriminate between ways. Add terms that are *domain-specific* words users would say.
+For semantic ways, `/ways-tests suggest` analyzes the way body text and recommends vocabulary additions. Not all suggestions should be added — body terms like "code" or "use" don't discriminate between ways. Add terms that are *domain-specific* words users would say.
 
 To verify the live system, include the way's keywords in a prompt and check that it fires (appears in system-reminder). Use `/ways` to see which ways have fired in the current session.
 
@@ -79,7 +79,7 @@ If you just ask "what are ways?" you get the 60-line overview. The authoring spe
 
 **Macros for live state**: A sub-way with `macro: prepend` can run a script that injects current state. The optimization way does this — its macro runs `way-match suggest` across all semantic ways and includes the results. The agent gets both the workflow guidance and the data it needs, without constructing any ad-hoc code.
 
-This pattern is self-improving: the tools that analyze the system (`way-match suggest`, `/test-way`) are themselves documented in ways that fire when you use them. You optimize ways by talking about optimizing ways.
+This pattern is self-improving: the tools that analyze the system (`way-match suggest`, `/ways-tests`) are themselves documented in ways that fire when you use them. You optimize ways by talking about optimizing ways.
 
 ## Project-Local Ways
 

--- a/docs/hooks-and-ways/matching.md
+++ b/docs/hooks-and-ways/matching.md
@@ -67,7 +67,7 @@ Good vocabulary terms are domain-specific words that **users would say** when as
 - **Skip**: Generic terms that don't discriminate — `code`, `use`, `make`, `change`
 - **Keep unused terms**: Vocabulary terms that don't appear in the way body are often intentional — they catch user prompts, not body text
 
-Use `/test-way suggest <way>` to find gaps and `/test-way score-all "prompt"` to check for cross-way false positives.
+Use `/ways-tests suggest <way>` to find gaps and `/ways-tests score-all "prompt"` to check for cross-way false positives.
 
 ### Sparsity over coverage
 

--- a/hooks/ways/init-project-ways.sh
+++ b/hooks/ways/init-project-ways.sh
@@ -73,8 +73,8 @@ Matching is additive — a way can have both pattern and semantic triggers.
 
 - Keep guidance compact and actionable
 - Include the *why* — agents apply better judgment when they understand the reason
-- Use `/test-way score <way> "sample prompt"` to verify matching
-- Use `/test-way suggest <way>` to find vocabulary gaps
+- Use `/ways-tests score <way> "sample prompt"` to verify matching
+- Use `/ways-tests suggest <way>` to find vocabulary gaps
 EOF
     echo "Created project ways template: $TEMPLATE"
   fi

--- a/hooks/ways/meta/knowledge/authoring/way.md
+++ b/hooks/ways/meta/knowledge/authoring/way.md
@@ -100,11 +100,11 @@ For state transitions and process flows, prefer Cypher-style notation over ASCII
 
 ## Testing Your Way
 
-Use `/test-way` to validate matching quality:
-- `/test-way score <way> "sample prompt"` — test a specific way
-- `/test-way score-all "sample prompt"` — rank all ways against a prompt
-- `/test-way suggest <way>` — analyze vocabulary gaps
-- `/test-way lint <way>` — validate frontmatter
+Use `/ways-tests` to validate matching quality:
+- `/ways-tests score <way> "sample prompt"` — test a specific way
+- `/ways-tests score-all "sample prompt"` — rank all ways against a prompt
+- `/ways-tests suggest <way>` — analyze vocabulary gaps
+- `/ways-tests lint <way>` — validate frontmatter
 
 For vocabulary tuning workflows, see the optimization sub-way (triggers on vocabulary/optimization discussion).
 

--- a/hooks/ways/meta/knowledge/optimization/way.md
+++ b/hooks/ways/meta/knowledge/optimization/way.md
@@ -26,10 +26,10 @@ provenance:
 suggest → interpret → apply → test → verify
 ```
 
-1. **Survey**: `/test-way suggest --all` (or `--all --summary` for overview)
+1. **Survey**: `/ways-tests suggest --all` (or `--all --summary` for overview)
 2. **Interpret**: Gaps vs intentional unused (see below)
-3. **Apply**: `/test-way suggest <way> --apply` (git-safe, shows diff)
-4. **Test**: `/test-way score-all "<sample prompt>"` to verify discrimination
+3. **Apply**: `/ways-tests suggest <way> --apply` (git-safe, shows diff)
+4. **Test**: `/ways-tests score-all "<sample prompt>"` to verify discrimination
 5. **Verify**: `bash tools/way-match/test-harness.sh --bm25-only` for regression
 
 ## Reading Suggest Output
@@ -49,7 +49,7 @@ suggest → interpret → apply → test → verify
 The goal isn't to maximize each way's score — it's to maximize the **semantic distance between ways**. Narrow, distinct vocabularies create sparsity: each way occupies its own region of the scoring space with minimal overlap. This means prompts activate exactly the right guidance, not a cluster of partially-relevant ways.
 
 ```bash
-/test-way score-all "the ambiguous prompt"
+/ways-tests score-all "the ambiguous prompt"
 ```
 
 Ideal outcome: one way scores well above threshold, others score well below. If two ways both match the same prompt, their semantic regions overlap — they need sharpening.

--- a/tests/README.md
+++ b/tests/README.md
@@ -69,10 +69,10 @@ Takes about 5 minutes. **Current baseline**: 8/8 PASS (steps 1-8).
 
 ### Ad-Hoc Vocabulary Testing
 
-The `/test-way` skill scores a prompt against all semantic ways and reports BM25 scores. Use it during vocabulary tuning to check discrimination between ways.
+The `/ways-tests` skill scores a prompt against all semantic ways and reports BM25 scores. Use it during vocabulary tuning to check discrimination between ways.
 
 ```
-/test-way "write some unit tests for this module"
+/ways-tests "write some unit tests for this module"
 ```
 
 ## Documentation Tests
@@ -107,9 +107,9 @@ bash governance/governance.sh --lint         # full governance lint
 | Scenario | Test |
 |----------|------|
 | Changed `way-match.c` or rebuilt binary | Fixture tests + integration tests |
-| Changed a way's vocabulary or threshold | Integration tests + `/test-way` |
+| Changed a way's vocabulary or threshold | Integration tests + `/ways-tests` |
 | Changed hook scripts (check-*.sh, inject-*.sh, match-way.sh) | Activation test |
-| Added a new way | Integration tests + `/test-way` + activation test |
+| Added a new way | Integration tests + `/ways-tests` + activation test |
 | Restructured way directories | All three test layers + symlink/path verification |
 | Added semantic matching to a way | Fixture tests + integration tests + activation test (step 4) |
 | Renamed or moved documentation files | Doc-graph |


### PR DESCRIPTION
## Summary

- **ADR-100**: Repurpose `/ways` from session diagnostic into a scaffolding wizard that interviews humans and creates/revises project-local ways
- **Rename**: `/test-way` → `/ways-tests` for namespace coherence (tab-completion under `/ways*`)
- **IR grounding**: Added "What This Actually Is" section to matching.md, connecting vocabulary tuning to its information retrieval heritage (Cranfield paradigm, BM25 lineage, TREC evaluation)

## What changed

| File | Change |
|------|--------|
| `commands/ways.md` | Replaced 5-line diagnostic with full wizard skill |
| `commands/test-way.md` → `commands/ways-tests.md` | Rename + updated internal refs |
| `docs/hooks-and-ways/matching.md` | New "What This Actually Is" section |
| `docs/architecture/system/ADR-100-*` | New ADR with session commitment framing |
| 7 other files | `/test-way` → `/ways-tests` reference updates |

## Design decisions

The wizard is a **session commitment** — invoking `/ways` dedicates the session to way work. Claude reads matching.md and extending.md upfront (context cost justified by the task). The skill leverages the existing trigger system recursively: talking about ways fires `meta/knowledge`, editing way.md fires `meta/knowledge/authoring`, etc.

## Way efficiency observed this session

This session used ~120k tokens across IR grounding, ADR design, skill implementation, and doc updates. Way firing stats:

- **12 of ~37 ways fired** (32% activation)
- **Each fired exactly once** (marker dedup working)
- **0 misfires** (no irrelevant injections)
- **~25 ways stayed silent** — incident, security, debugging, API, release, teams, etc.
- Estimated **1,000-1,500 lines of guidance avoided** vs monolithic CLAUDE.md

## Test plan

- [ ] Invoke `/ways` in a fresh session on a project — verify it reads docs, detects state, interviews
- [ ] Verify `meta/knowledge` fires when wizard discusses ways
- [ ] Verify `meta/knowledge/authoring` fires when wizard creates a way.md
- [ ] Invoke `/ways-tests` — confirm rename works and all subcommands function
- [ ] Check tab-completion: `/ways` + tab shows both `/ways` and `/ways-tests`