### PR TITLE
Add ship/land/merge triggers to github way

### DIFF
--- a/hooks/ways/softwaredev/delivery/github/way.md
+++ b/hooks/ways/softwaredev/delivery/github/way.md
@@ -1,8 +1,8 @@
 ---
 description: GitHub pull requests, issues, code review, CI checks, repository management
-vocabulary: pr pullrequest issue review checks ci label milestone fork repository upstream draft
+vocabulary: pr pullrequest issue review checks ci label milestone fork repository upstream draft ship land merge
 threshold: 2.0
-pattern: github|\ issue|pull.?request|\ pr\ |\ pr$|review.?(pr|comment)|merge.?request
+pattern: github|\ issue|pull.?request|\ pr\ |\ pr$|review.?(pr|comment)|merge.?request|\bship\s+(it|this|the)\b|\bland\s+(it|this)\b|\bmerge\s+(it|this)\b
 commands: ^gh\ |^gh$
 macro: prepend
 scope: agent, subagent


### PR DESCRIPTION
## Summary
- Add `ship land merge` to delivery/github vocabulary
- Add regex patterns for "ship it/this/the", "land it/this", "merge it/this"
- Ensures /ship skill gets github way context injected

## Test plan
- Verified "ship it", "land this", "merge this" all trigger via regex
- No false positives on "merge conflict", "the ship sailed", unrelated prompts
- No cross-way BM25 collisions (only delivery/release scores, below threshold)