### PR TITLE
feat(ship): gate review on active contributors

### DIFF
--- a/hooks/ways/softwaredev/delivery/github/macro.sh
+++ b/hooks/ways/softwaredev/delivery/github/macro.sh
@@ -55,6 +55,11 @@ wait
 CONTRIBUTORS=$(jq -r 'length' "$WORK_DIR/contributors.json" 2>/dev/null)
 CURRENT_USER=$(cat "$WORK_DIR/user.txt" 2>/dev/null)
 
+# Active contributors — anyone who committed in the last 90 days
+# Local git log is faster and more accurate than API for this
+ACTIVE_CONTRIBUTORS=$(git log --since="90 days ago" --format='%aN' 2>/dev/null | sort -u | wc -l)
+ACTIVE_CONTRIBUTORS=${ACTIVE_CONTRIBUTORS:-0}
+
 # Repo details
 DESCRIPTION=$(jq -r '.description // empty' "$WORK_DIR/repo.json" 2>/dev/null)
 TOPICS=$(jq -r '.topics | length' "$WORK_DIR/repo.json" 2>/dev/null)
@@ -106,19 +111,21 @@ fi
 # ============================================================
 
 if [[ -n "$CONTRIBUTORS" ]]; then
-  if [[ "$CONTRIBUTORS" -le 2 ]]; then
-    echo "**Context**: Solo/pair project ($CONTRIBUTORS contributors)"
+  # Classify by active contributors (last 90 days), not total
+  if [[ "$ACTIVE_CONTRIBUTORS" -le 2 ]]; then
+    echo "**Context**: Solo/pair project ($ACTIVE_CONTRIBUTORS active, $CONTRIBUTORS total contributors)"
     echo "- PRs recommended even for solo work — they create history, enable CI, and build good habits"
     echo "- Lightweight PRs are fine: a title and a few bullet points"
   else
     # Reuse saved contributors response instead of re-fetching
     REVIEWERS=$(jq -r '.[0:5][].login' "$WORK_DIR/contributors.json" 2>/dev/null \
       | grep -v "$CURRENT_USER" | head -3 | tr '\n' ', ' | sed 's/,$//')
-    echo "**Context**: Team project ($CONTRIBUTORS contributors)"
-    echo "- PR required for all changes"
+    echo "**Context**: Team project ($ACTIVE_CONTRIBUTORS active, $CONTRIBUTORS total contributors)"
+    echo "- PR required for all changes — review before merge"
     if [[ -n "$REVIEWERS" ]]; then
       echo "- Potential reviewers: $REVIEWERS"
     fi
+    echo "- Consider [Claude Code Review](https://claude.com/blog/code-review) for automated multi-agent PR analysis (\$15-25/review, Team/Enterprise plans)"
   fi
 fi
 

--- a/hooks/ways/softwaredev/delivery/github/way.md
+++ b/hooks/ways/softwaredev/delivery/github/way.md
@@ -39,6 +39,7 @@ We use PRs for all changes, including solo projects. A PR without reviewers stil
 
 - **Solo/pair**: Lightweight PRs — a title and a few bullets is enough
 - **Team**: Full PR with context, reviewers, and linked issues
+- **Team (3+ contributors)**: Consider enabling [Claude Code Review](https://claude.com/blog/code-review) — automated multi-agent PR analysis that catches bugs skimmed reviews miss. $15-25/review, Team/Enterprise plans, org spending caps available
 
 ## When User Mentions GitHub
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -8,6 +8,11 @@ allowed-tools: Bash, Read, Grep, Glob
 
 Deliver current work to main. Assess the current state and pick up from wherever the user is.
 
+## Arguments
+
+- `/ship` — default flow, adapts review gate to repo flavor
+- `/ship full-sail` — skip the review pause (solo/pair repos only; team repos still pause)
+
 ## Assess First
 
 Run these in parallel to determine current position in the flow:
@@ -18,6 +23,19 @@ git branch --show-current       # On main or a feature branch?
 git log --oneline main..HEAD    # Commits ahead of main?
 git remote show origin 2>&1     # Remote tracking state?
 ```
+
+Also check repo flavor for review gating:
+
+```bash
+# Active contributors in last 90 days
+git log --since="90 days ago" --format='%aN' | sort -u | wc -l
+```
+
+- **≤2 active**: Solo/pair — lightweight PRs, review pause optional
+- **3+ active**: Team — review pause mandatory, suggest reviewers
+
+If the GitHub way has already injected context (look for `**Context**: Team project` or
+`**Context**: Solo/pair project` in the conversation), use that instead of re-checking.
 
 ## Flow Steps (skip what's already done)
 
@@ -59,11 +77,18 @@ EOF
 Keep the title under 70 characters. Summary should be 1-3 bullets.
 For small/obvious changes, the test plan can be brief.
 
-### 5. Review (scope-dependent)
+### 5. Review Gate
 
-- **Trivial** (typos, config, single-file): skip review, merge directly
+**Team repos (3+ active contributors):**
+- Always pause here. State the change scope and suggest reviewers.
+- Do NOT proceed to merge without explicit user approval.
+- Exception: `/ship full-sail` is rejected for team repos — tell the user why.
+
+**Solo/pair repos (≤2 active contributors):**
+- **Trivial** (typos, config, single-file): merge directly
 - **Small** (1-3 files, clear intent): quick self-review of the diff is enough
-- **Significant** (architecture, multi-file, behavioral): suggest the user review or request a reviewer
+- **Significant** (architecture, multi-file, behavioral): suggest the user review
+- `/ship full-sail` skips the pause entirely for any change size
 
 State your assessment and let the user decide.
 
@@ -91,6 +116,7 @@ git branch -d <branch>
 ## Key Principles
 
 - **Don't ask permission for each step** — assess state, propose the full remaining flow, then execute
-- **Pause only at decision points**: commit message wording, PR description, review scope
+- **Pause only at decision points**: commit message wording, PR description, review gate
 - **If already mid-flow**, pick up from current state — don't restart
 - **One commit is fine** for most changes; only split if there are genuinely separate concerns
+- **Repo flavor drives review**, not just change size — a one-line fix in a team repo still pauses


### PR DESCRIPTION
## Summary
- GitHub macro now classifies repos by **active contributors** (commits in last 90 days) instead of total contributor count
- Ship skill adapts review gate to repo flavor: team repos (3+ active) always pause, solo/pair repos use change-size heuristic
- Added `/ship full-sail` argument to skip review pause on solo/pair repos

## Test plan
- [ ] Run macro on a solo repo — verify output shows `(1 active, N total contributors)`
- [ ] Run macro on a team repo — verify 3+ active triggers team classification
- [ ] `/ship` on solo repo — confirm trivial changes merge without pause
- [ ] `/ship` on team repo — confirm review gate blocks merge
- [ ] `/ship full-sail` on team repo — confirm it's rejected with explanation