### PR TITLE
feat(ways): detect stale ways config at session start

### DIFF
--- a/hooks/ways/show-core.sh
+++ b/hooks/ways/show-core.sh
@@ -22,15 +22,35 @@ echo ""
 echo "---"
 echo "_Ways version: ${WAYS_VERSION}_"
 
+# Check if ways might be stale using last fetch timestamp (no network call)
+# FETCH_HEAD mtime tells us when we last fetched — if it's old, nudge the user
+FETCH_HEAD="$CLAUDE_DIR/.git/FETCH_HEAD"
+if [[ -f "$FETCH_HEAD" ]]; then
+  FETCH_AGE_DAYS=$(( ( $(date +%s) - $(stat -c '%Y' "$FETCH_HEAD" 2>/dev/null || stat -f '%m' "$FETCH_HEAD" 2>/dev/null || echo 0) ) / 86400 ))
+  if (( FETCH_AGE_DAYS >= 3 )); then
+    echo ""
+    echo "**Ways last synced ${FETCH_AGE_DAYS} days ago.** This session may be missing recent improvements."
+    echo "Updating is highly recommended: \`git -C ~/.claude pull\`"
+  fi
+elif git -C "$CLAUDE_DIR" remote get-url origin &>/dev/null; then
+  # Has a remote but never fetched — worth mentioning
+  echo ""
+  echo "**Ways have never been synced with remote.** Updating is highly recommended: \`git -C ~/.claude pull\`"
+fi
+
 # If dirty, enumerate what's changed
 if [[ "$WAYS_VERSION" == *-dirty ]]; then
-  # Get dirty files sorted by most recently modified
   dirty_files=$(git -C "$CLAUDE_DIR" status --short 2>/dev/null | awk '{print $NF}')
   dirty_count=$(echo "$dirty_files" | wc -l | tr -d ' ')
   MAX_SHOW=5
 
   echo ""
-  echo "_Uncommitted changes (${dirty_count} file$([ "$dirty_count" -ne 1 ] && echo s)):_"
+  if (( dirty_count >= 4 )); then
+    echo "**Uncommitted local changes (${dirty_count} files)** — not tracked by git."
+    echo "Other sessions won't see these. Commit to keep, or discard to match remote."
+  else
+    echo "**Uncommitted local changes (${dirty_count} file$([ "$dirty_count" -ne 1 ] && echo s)):**"
+  fi
 
   # Sort by mtime descending (most recently changed first)
   sorted_files=$(while IFS= read -r f; do
@@ -43,13 +63,17 @@ if [[ "$WAYS_VERSION" == *-dirty ]]; then
   while IFS= read -r fullpath; do
     [[ -z "$fullpath" ]] && continue
     relpath="${fullpath#$CLAUDE_DIR/}"
-    echo "_  ${relpath}_"
+    echo "- \`${relpath}\`"
   done <<< "$sorted_files"
 
   if (( dirty_count > MAX_SHOW )); then
-    echo "_  ... and $(( dirty_count - MAX_SHOW )) more_"
+    echo "- ... and $(( dirty_count - MAX_SHOW )) more"
   fi
-  echo "_Run \`git -C ~/.claude status --short\` to list all._"
+
+  if (( dirty_count < 4 )); then
+    echo ""
+    echo "_Run \`git -C ~/.claude status\` to review._"
+  fi
 fi
 
 # Mark core as injected for this session


### PR DESCRIPTION
## Summary
- Session startup checks `FETCH_HEAD` mtime to detect when ways were last synced — no network calls
- Warns when 3+ days stale: "Updating is highly recommended: `git -C ~/.claude pull`"
- Improved dirty file display: bold headers, bullet points, tiered urgency (4+ files = drift warning)

## Test plan
- [ ] Fresh session after recent pull — no stale warning
- [ ] `touch -d "5 days ago" ~/.claude/.git/FETCH_HEAD` — verify stale warning appears
- [ ] Dirty files render as bullet list with backtick paths
- [ ] 4+ dirty files trigger the "drifting" escalation message