### PR TITLE
fix(ways): add semantic matching to all 11 regex-only ways

### DIFF
--- a/hooks/ways/itops/incident/way.md
+++ b/hooks/ways/itops/incident/way.md
@@ -1,4 +1,7 @@
 ---
+description: Incident response tiers, escalation paths, MTTR targets, alert triage, and remediation workflows
+vocabulary: incident response escalation support tier l0 l1 l2 mttr mean time alert triage remediate on-call outage severity page production down broken
+threshold: 2.0
 pattern: incident.?response|l0.?support|l1.?support|l2.?support|escalat|mttr|mean.?time|alert.?(response|triage)|remediat
 scope: agent, subagent
 ---

--- a/hooks/ways/itops/policy/way.md
+++ b/hooks/ways/itops/policy/way.md
@@ -1,4 +1,7 @@
 ---
+description: Operation classification, policy enforcement, approval gates, blast radius assessment, and risk scoring
+vocabulary: operation class policy enforcement approval gate workflow blast radius risk score level dangerous safe critical
+threshold: 2.0
 pattern: operation.?class|policy.?(engine|enforcement)|approval.?(gate|level|workflow)|blast.?radius|risk.?(class|level|score)
 scope: agent, subagent
 ---

--- a/hooks/ways/itops/proposals/way.md
+++ b/hooks/ways/itops/proposals/way.md
@@ -1,4 +1,7 @@
 ---
+description: Structured proposals for human approval before executing high-risk operations, human-in-the-loop workflows
+vocabulary: proposal approval human loop review confirm dangerous operation lifecycle primitive structured request permission sign-off authorize before running
+threshold: 2.0
 pattern: proposal.?(primitive|lifecycle|structure)|human.?in.?(the.?)?loop|approval.?workflow|operation.?proposal
 scope: agent, subagent
 ---

--- a/hooks/ways/itops/runbooks/way.md
+++ b/hooks/ways/itops/runbooks/way.md
@@ -1,4 +1,7 @@
 ---
+description: Runbook automation, executable playbooks, SOPs as code, operational procedures
+vocabulary: runbook playbook sop procedure operational automation executable standard checklist step-by-step operations
+threshold: 2.0
 pattern: runbook|runbook.?(automation|executable)|playbook|sop.?(automation|as.?code)|operational.?procedure
 scope: agent, subagent
 ---

--- a/hooks/ways/meta/introspection/way.md
+++ b/hooks/ways/meta/introspection/way.md
@@ -1,4 +1,7 @@
 ---
+description: PR creation as a reflection point — pause and consider what was learned this session
+vocabulary: pull request create pr open pr ship merge review reflect session learning introspection
+threshold: 2.5
 pattern: pull.?request|create.*pr|pr.*create|write.*pr|open.*pr
 commands: gh\ pr\ create
 macro: prepend

--- a/hooks/ways/meta/knowledge/way.md
+++ b/hooks/ways/meta/knowledge/way.md
@@ -1,4 +1,7 @@
 ---
+description: Overview of the ways system — how ways, skills, and hooks relate, domain organization, matching modes
+vocabulary: ways way knowledge guidance context inject hook trigger matching semantic vocabulary domain
+threshold: 2.0
 pattern: (^| )ways?( |$)|knowledge|guidance|context.?inject
 scope: agent, subagent
 provenance:

--- a/hooks/ways/meta/memory/way.md
+++ b/hooks/ways/meta/memory/way.md
@@ -1,4 +1,6 @@
 ---
+description: Persistent memory system — MEMORY.md, topic files, what to record and when
+vocabulary: remember memory save note forget recall persist session learning gotcha pattern
 trigger: context-threshold
 threshold: 80
 pattern: remember|save.*(to|this|that).*memory|note.*(for|this).*(later|next)|don't forget|keep.*in.*mind

--- a/hooks/ways/meta/skills/way.md
+++ b/hooks/ways/meta/skills/way.md
@@ -1,4 +1,7 @@
 ---
+description: Claude Code skills — SKILL.md format, creation, discovery, slash commands, frontmatter
+vocabulary: skill slash command SKILL.md create author write invoke user-invocable plugin
+threshold: 2.0
 pattern: skill|SKILL\.md|skill.?(creation|author|write)|claude.?code.?skill|~\/\.claude\/skills
 scope: agent, subagent
 ---

--- a/hooks/ways/meta/subagents/way.md
+++ b/hooks/ways/meta/subagents/way.md
@@ -1,4 +1,7 @@
 ---
+description: Sub-agent delegation — when and how to spawn specialized agents for token-intensive work
+vocabulary: subagent delegate spawn agent background task parallel worker teammate
+threshold: 2.0
 pattern: subagent|delegat|spawn.*agent|review.*pr|plan.*task|organiz.*docs
 scope: agent
 ---

--- a/hooks/ways/meta/tracking/way.md
+++ b/hooks/ways/meta/tracking/way.md
@@ -1,4 +1,7 @@
 ---
+description: Cross-session work tracking — persistent todo files in .claude/ for multi-session continuity
+vocabulary: tracking cross-session multi-session persistent todo picking resume continuity progress
+threshold: 2.0
 pattern: tracking.?file|cross.?session|multi.?session|picking.?up|\.claude/todo
 files: \.claude/todo-.*\.md$
 scope: agent, subagent

--- a/hooks/ways/softwaredev/architecture/adr/way.md
+++ b/hooks/ways/softwaredev/architecture/adr/way.md
@@ -1,4 +1,7 @@
 ---
+description: Architecture Decision Records — creating, managing, and referencing ADRs for technical choices
+vocabulary: adr architecture decision record design pattern technical choice trade-off rationale alternative
+threshold: 2.0
 pattern: (^| )adr( |$)|architect|decision|design.?pattern|technical.?choice|trade.?off
 files: docs/architecture/.*\.md$
 macro: prepend


### PR DESCRIPTION
## Summary
- All 11 regex-only ways now have `description:` + `vocabulary:` + `threshold:` for BM25 semantic matching
- Existing `pattern:`/`files:`/`commands:` triggers kept as supplementary
- Vocabulary tuned against natural language prompts that regex would miss
- `lint-ways.sh --strict`: 0 errors, 0 warnings across all 66 ways
- Test harness: 0 FP, no regressions

## Test plan
- [x] All 11 ways score above threshold on natural language prompts
- [x] Test harness: 74 tests, 0 FP, 10/10 co-activation
- [x] Lint strict mode: full compliance