### PR TITLE
feat(ways): implementation way — post-ADR planning with progressive disclosure

### DIFF
--- a/hooks/ways/softwaredev/delivery/implement/macro.sh
+++ b/hooks/ways/softwaredev/delivery/implement/macro.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Implementation way macro — progressive disclosure of parallelization guidance
+#
+# Lightweight: way.md always shows the briefing protocol
+# This macro adds detailed planning tables only when the project
+# signals enough complexity to warrant parallelization thinking.
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# --- Complexity signals ---
+has_adrs=false
+has_tracking=false
+file_count=0
+
+# Check for ADRs (suggests architectural work, not a quick fix)
+if [[ -d "$PROJECT_DIR/docs/architecture" ]]; then
+  adr_count=$(find "$PROJECT_DIR/docs/architecture" -name "ADR-*.md" 2>/dev/null | wc -l)
+  [[ "$adr_count" -gt 0 ]] && has_adrs=true
+fi
+
+# Check for active tracking files (signals multi-session complexity)
+tracking_count=$(find "$PROJECT_DIR/.claude" -name "todo-*.md" 2>/dev/null | wc -l)
+[[ "$tracking_count" -gt 0 ]] && has_tracking=true
+
+# Estimate project size (rough proxy for parallelization relevance)
+if command -v find >/dev/null 2>&1; then
+  file_count=$(find "$PROJECT_DIR" -maxdepth 3 -name "*.md" -o -name "*.py" -o -name "*.js" -o -name "*.ts" -o -name "*.go" -o -name "*.rs" -o -name "*.sh" -o -name "*.c" -o -name "*.h" 2>/dev/null | wc -l)
+fi
+
+# --- Decide disclosure level ---
+# Show full parallelization guidance if any complexity signal fires
+if $has_adrs || $has_tracking || [[ "$file_count" -gt 20 ]]; then
+  cat <<'EOF'
+
+## Safe Parallelization
+
+Enter plan mode and think through work collision **before** creating tasks. Defend each parallelization decision — if you can't articulate why two tasks won't collide, they're sequential.
+
+### Collision Analysis
+
+| Risk | Example | Verdict |
+|------|---------|---------|
+| Same file | Two tasks editing `config.yaml` | Sequential — never parallelize |
+| Import chain | Task A edits module, Task B edits its caller | Sequential — interface changes cascade |
+| Independent modules | New utility + new test fixtures | Safe to parallelize |
+| Read-only research | Investigating patterns across codebase | Safe as subagent (no edits) |
+| Independent test files | Tests for unrelated features | Safe to parallelize |
+
+### Isolation Strategies
+
+| Strategy | When to Use | How |
+|----------|-------------|-----|
+| **Worktree** | Tasks editing different file sets with no shared imports | `Agent(isolation: "worktree")` |
+| **Subagent** | Research, review, analysis — read-only work | `Agent(subagent_type: ...)` |
+| **Sequential** | Tasks with file overlap or dependency chains | One after another in main context |
+
+### Rules
+
+- **When in doubt, go sequential.** Collision cost far exceeds waiting cost.
+- **Never parallelize tasks that touch the same file.** Not even "different sections."
+- **Worktree tasks must be self-contained.** They can't see main-tree edits until merged back.
+- **Subagents for research are always safe.** Read-only work can always run in parallel.
+
+### Execution Order
+
+1. Start sequential tasks first (critical path)
+2. Launch parallelizable tasks together when dependencies are met
+3. Review worktree changes before integrating
+4. Run tests after each integration point, not just at the end
+EOF
+else
+  # Lightweight hint — don't dump tables for small/simple projects
+  echo ""
+  echo "For multi-file work, enter plan mode first and think about whether tasks can safely run in parallel (worktrees for independent file sets, subagents for read-only research, sequential for anything that shares files)."
+fi

--- a/hooks/ways/softwaredev/delivery/implement/way.md
+++ b/hooks/ways/softwaredev/delivery/implement/way.md
@@ -1,0 +1,41 @@
+---
+description: Post-ADR implementation — planning work breakdown, safe parallelization, and briefing the human before executing
+vocabulary: implement build begin start work execute plan breakdown parallelize worktree task sprint kick off begin coding
+threshold: 2.0
+macro: append
+scope: agent
+---
+# Implementation Way
+
+## Do Not Reset Context
+
+The discussion that led to the ADR is valuable context. Stay in the same session. Use the planning tool to transition from deliberation to execution — don't start a fresh conversation.
+
+## The Briefing
+
+Before creating any tasks or writing any code, **present the implementation plan to the human as a briefing.** This is not optional. The briefing serves as alignment, not ceremony.
+
+### What the Briefing Covers
+
+1. **What we're building** — one paragraph restating the decision in implementation terms, not ADR terms
+2. **Why this approach** — defend the implementation strategy
+3. **Work breakdown** — the discrete tasks, with dependencies made explicit
+4. **Parallelization plan** — which tasks can run concurrently and why that's safe
+5. **Risk areas** — where collisions, complexity, or unknowns live
+6. **Expected outcome** — what the codebase looks like when we're done
+
+### Briefing Style
+
+**Defend the plan.** Commit to a position, state what you intend to do, and explain why it's the right approach. Don't hedge with "we could maybe..." or present a menu of options. The act of defending forces you to surface your reasoning, find weaknesses, and revise before presenting. If the defense doesn't hold up under your own scrutiny, revise the plan — then defend the revised version.
+
+The human's role is to challenge, redirect, or approve. That pushback loop — defend, challenge, revise — is how alignment happens. A plan that can't survive a briefing shouldn't survive implementation either.
+
+### Pushback Goes Both Ways
+
+The human will sometimes suggest approaches that won't work — wrong tool, wrong order, wrong abstraction. **Push back when you see a problem**, but separate the intent from the idea. The human usually has the right goal and the wrong mechanism. Your job is to understand *what they're trying to achieve* and propose a better path to get there.
+
+Don't just say "that won't work" — say "I think you're trying to [intent]. Here's why [specific idea] is risky, and here's what I'd do instead to get the same result." Preserve the intent, fix the approach.
+
+## After the Briefing
+
+Once the human approves (or you adjust based on their feedback), create tasks using `TaskCreate` with enough detail for a subagent or post-compaction agent to execute cold — file paths, ADR reference, dependencies, and isolation strategy.


### PR DESCRIPTION
## Summary

- New way at `softwaredev/delivery/implement/` bridging ADR acceptance → code execution
- **way.md**: Briefing protocol (defend the plan, pushback both ways, separate intent from mechanism)
- **macro.sh**: Progressive disclosure — full parallelization tables for complex projects (has ADRs, tracking files, or 20+ source files), one-liner hint for simple projects

## Design

The way fires on vocabulary like "implement", "build", "begin work", "plan breakdown", "parallelize". It co-fires healthily with `adr-context` (which says "check ADRs first") — complementary, not competing.

Known near-miss: "ok let's implement the feature we discussed" scores 1.75 vs threshold 2.0. Accepted — correct IDF from ADR-107 Phase 1 will address this systemically rather than tuning against the current stale 7-doc corpus.

## Scoring

- 5/6 should-match prompts: MATCH
- 7/7 should-not-match prompts: miss (0 false positives)
- Lint: 0 errors, 0 warnings

## Test plan

- [x] `lint-ways.sh` passes clean
- [x] BM25 scoring: 0 FP across negative prompt battery
- [x] Macro progressive disclosure: full tables on complex project, one-liner on empty project
- [x] Macro is executable (`chmod +x`)