### PR TITLE
fix(ci): macos-13 runner deprecated, cross-compile on macos-latest

### DIFF
--- a/.github/workflows/build-way-embed.yml
+++ b/.github/workflows/build-way-embed.yml
@@ -21,8 +21,9 @@ jobs:
             platform: linux-x86_64
           - os: ubuntu-24.04-arm
             platform: linux-aarch64
-          - os: macos-13
+          - os: macos-latest
             platform: darwin-x86_64
+            cmake_extra: -DCMAKE_OSX_ARCHITECTURES=x86_64
           - os: macos-latest
             platform: darwin-arm64
 
@@ -44,14 +45,21 @@ jobs:
         run: |
           mkdir -p build ../../bin
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_extra }} ..
           cmake --build . --target way-embed -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
           cd ..
           cp build/way-embed ../../bin/way-embed-${{ matrix.platform }}
 
       - name: Smoke test
+        if: ${{ !matrix.cmake_extra }}
         run: |
           bin/way-embed-${{ matrix.platform }} --version
+
+      - name: Verify binary exists (cross-compiled)
+        if: ${{ matrix.cmake_extra }}
+        run: |
+          file bin/way-embed-${{ matrix.platform }}
+          ls -lh bin/way-embed-${{ matrix.platform }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
macos-13 runner no longer available. Use macos-latest (ARM) with CMAKE_OSX_ARCHITECTURES=x86_64 for the darwin-x86_64 build. Skip smoke test for cross-compiled binary.