### PR TITLE
fix(ci): GGML_NATIVE=OFF for darwin-x86_64 cross-compile

### DIFF
--- a/.github/workflows/build-way-embed.yml
+++ b/.github/workflows/build-way-embed.yml
@@ -23,7 +23,7 @@ jobs:
             platform: linux-aarch64
           - os: macos-latest
             platform: darwin-x86_64
-            cmake_extra: -DCMAKE_OSX_ARCHITECTURES=x86_64
+            cmake_extra: -DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_NATIVE=OFF
           - os: macos-latest
             platform: darwin-arm64
 


### PR DESCRIPTION
llama.cpp detects host CPU (apple-m3) and uses it as -march target, which is invalid when cross-compiling to x86_64. Disabling GGML_NATIVE uses generic x86_64 instead.