### PR TITLE
feat(embed): ADR-109 — project-scope way embedding with manifest staleness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,8 @@
 !governance-report
 !ways-stats
 !embed-status
+!embed-corpus
+!lint-ways
 !governance/
 !governance/README.md
 !governance/*.py

--- a/embed-corpus
+++ b/embed-corpus
@@ -1,0 +1,1 @@
+tools/way-match/generate-corpus.sh

--- a/governance/governance.sh
+++ b/governance/governance.sh
@@ -68,7 +68,25 @@ while [[ $# -gt 0 ]]; do
     --lint)      MODE="lint"; shift ;;
     --json)      JSON_OUT=true; shift ;;
     --manifest)  [[ $# -lt 2 ]] && { echo "Error: --manifest requires a file path" >&2; exit 1; }; MANIFEST="$2"; shift 2 ;;
-    --help|-h)   head -16 "$0" | tail -15 | sed 's/^# \?//'; exit 0 ;;
+    --help|-h)
+      _B='' _D='' _C='' _R=''
+      if [[ -t 1 ]]; then _B='\033[1m' _D='\033[2m' _C='\033[0;36m' _R='\033[0m'; fi
+      echo -e "${_B}governance-report${_R} — Provenance traceability for ways"
+      echo ""
+      echo -e "  ${_C}Usage:${_R}  governance-report [mode] [--json]"
+      echo ""
+      echo -e "  ${_D}(default)          Coverage report${_R}"
+      echo -e "  ${_D}--trace WAY        End-to-end trace for a way${_R}"
+      echo -e "  ${_D}--control PATTERN   Which ways implement a control${_R}"
+      echo -e "  ${_D}--policy PATTERN    Which ways derive from a policy${_R}"
+      echo -e "  ${_D}--gaps             Ways without provenance${_R}"
+      echo -e "  ${_D}--stale [DAYS]     Stale verified dates (default: 90)${_R}"
+      echo -e "  ${_D}--active           Cross-reference with firing stats${_R}"
+      echo -e "  ${_D}--matrix           Flat: way | control | justification${_R}"
+      echo -e "  ${_D}--lint             Validate provenance integrity${_R}"
+      echo -e "  ${_D}--json             Machine-readable output (any mode)${_R}"
+      exit 0
+      ;;
     *)           echo "Unknown option: $1 (try --help)" >&2; exit 1 ;;
   esac
 done

--- a/hooks/ways/check-embedding-staleness.sh
+++ b/hooks/ways/check-embedding-staleness.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Embedding corpus staleness check — runs at session start (ADR-109)
+#
+# Checks global ways + current project only. If either is stale,
+# triggers a full corpus regen (which sweeps all valid projects).
+#
+# Cost: one find+sha256sum for global + one for current project (~10ms).
+# Full project crawl happens in generate-corpus.sh, not here.
+#
+# Output: none on fresh, silent background regen on stale.
+
+set -euo pipefail
+
+XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
+MANIFEST="${XDG_WAY}/embed-manifest.json"
+CORPUS="${XDG_WAY}/ways-corpus.jsonl"
+CORPUS_GEN="${HOME}/.claude/tools/way-match/generate-corpus.sh"
+WAYS_DIR="${HOME}/.claude/hooks/ways"
+REGEN_LOG="${XDG_WAY}/regen.log"
+
+# Current project from Claude Code environment
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+
+# Need jq for manifest parsing
+command -v jq &>/dev/null || exit 0
+
+# No corpus generator → nothing to do
+[[ -x "$CORPUS_GEN" ]] || exit 0
+
+# Shared library: content_hash, resolve_project_path
+EMBED_LIB="${HOME}/.claude/hooks/ways/embed-lib.sh"
+# shellcheck source=embed-lib.sh
+[[ -f "$EMBED_LIB" ]] && source "$EMBED_LIB" || exit 0
+
+# ── Missing manifest or corpus → full regen ──────────────────────
+if [[ ! -f "$MANIFEST" || ! -f "$CORPUS" ]]; then
+  bash "$CORPUS_GEN" --quiet >> "$REGEN_LOG" 2>&1 &
+  exit 0
+fi
+
+# ── Check global ways staleness ──────────────────────────────────
+STALE=false
+
+manifest_global_hash=$(jq -r '.global_hash // empty' "$MANIFEST" 2>/dev/null)
+current_global_hash=$(content_hash "$WAYS_DIR")
+
+if [[ "$manifest_global_hash" != "$current_global_hash" ]]; then
+  STALE=true
+fi
+
+# ── Check current project ways staleness ─────────────────────────
+# Only checks the project we're in, not all projects. The full crawl
+# happens in generate-corpus.sh when regen is triggered.
+if [[ "$STALE" == "false" && -n "$PROJECT_DIR" && -d "${PROJECT_DIR}/.claude/ways" ]]; then
+  # Encode project path the same way Claude Code does
+  encoded=$(echo "$PROJECT_DIR" | tr '/' '-')
+
+  # Check marker
+  marker="${PROJECT_DIR}/.claude/.ways-embed"
+  if [[ ! -f "$marker" ]] || [[ "$(cat "$marker" 2>/dev/null | tr -d '[:space:]')" != "disinclude" ]]; then
+    manifest_hash=$(jq -r --arg k "$encoded" '.projects[$k].ways_hash // empty' "$MANIFEST" 2>/dev/null)
+
+    if [[ -z "$manifest_hash" ]]; then
+      # Project with ways not yet in manifest → stale
+      STALE=true
+    else
+      current_hash=$(content_hash "${PROJECT_DIR}/.claude/ways")
+      if [[ "$manifest_hash" != "$current_hash" ]]; then
+        STALE=true
+      fi
+    fi
+  fi
+fi
+
+# ── Trigger regen if stale ───────────────────────────────────────
+# Full regen sweeps all valid projects, not just the current one.
+# Logs to regen.log so persistent failures don't silently retry.
+if [[ "$STALE" == "true" ]]; then
+  echo "[$(date -Iseconds)] staleness detected, triggering regen" >> "$REGEN_LOG"
+  bash "$CORPUS_GEN" --quiet >> "$REGEN_LOG" 2>&1 &
+fi

--- a/hooks/ways/embed-lib.sh
+++ b/hooks/ways/embed-lib.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Shared library for ways tooling — sourced by generate-corpus.sh,
+# check-embedding-staleness.sh, embed-status.sh, and lint-ways.sh.
+#
+# Provides:
+#   content_hash         — content-addressed hash of way files
+#   resolve_project_path — decode Claude Code's lossy path encoding
+#   json_escape          — safe string embedding in JSON
+#   enumerate_projects   — iterate all projects with .claude/ways/
+
+# Content-addressed hash of all way.md files in a directory.
+# Immune to clock skew, catches uncommitted edits.
+content_hash() {
+  local dir="$1"
+  if command -v sha256sum &>/dev/null; then
+    find "$dir" -name "way.md" -type f -exec sha256sum {} + 2>/dev/null | sort | sha256sum | cut -d' ' -f1
+  elif command -v shasum &>/dev/null; then
+    find "$dir" -name "way.md" -type f -exec shasum -a 256 {} + 2>/dev/null | sort | shasum -a 256 | cut -d' ' -f1
+  else
+    echo "no-hash-tool"
+  fi
+}
+
+# Resolve real project path from Claude Code's encoded directory name.
+# Claude Code's path encoding (/ → -) is lossy — paths with hyphens
+# can't be decoded. We read sessions-index.json for the real path.
+resolve_project_path() {
+  local encoded_dir="$1"
+  local projects_dir="${HOME}/.claude/projects"
+  local idx="${projects_dir}/${encoded_dir}/sessions-index.json"
+  if [[ -f "$idx" ]] && command -v jq &>/dev/null; then
+    jq -r '.entries[0].projectPath // empty' "$idx" 2>/dev/null
+  fi
+}
+
+# Escape a string for safe JSON embedding (handles quotes and backslashes)
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+# Greedily resolve an encoded path against the filesystem.
+# Splits on -, accumulates segments into path components, testing
+# the filesystem at each step to distinguish / from - in the original.
+# e.g., -home-aaron-Projects-app-github-manager resolves to
+# /home/aaron/Projects/app/github-manager
+_resolve_encoded_path() {
+  local encoded="$1"
+  # Split into segments on -
+  local IFS='-'
+  local segments=()
+  read -ra segments <<< "${encoded#-}"
+
+  local current=""
+  local pending=""
+
+  for seg in "${segments[@]}"; do
+    if [[ -z "$pending" ]]; then
+      # Try as new path component: current/seg
+      if [[ -d "${current}/${seg}" ]]; then
+        current="${current}/${seg}"
+      else
+        # Start accumulating a hyphenated name
+        pending="$seg"
+      fi
+    else
+      # We're accumulating — try both:
+      # 1. pending-seg as a single hyphenated component
+      # 2. pending as component, seg as new component
+      if [[ -d "${current}/${pending}-${seg}" ]]; then
+        current="${current}/${pending}-${seg}"
+        pending=""
+      elif [[ -d "${current}/${pending}/${seg}" ]]; then
+        current="${current}/${pending}/${seg}"
+        pending=""
+      else
+        # Keep accumulating
+        pending="${pending}-${seg}"
+      fi
+    fi
+  done
+
+  # Handle remaining pending segment
+  if [[ -n "$pending" ]]; then
+    if [[ -d "${current}/${pending}" ]]; then
+      current="${current}/${pending}"
+    else
+      return  # couldn't resolve
+    fi
+  fi
+
+  [[ -d "$current" ]] && echo "$current"
+}
+
+# Enumerate all Claude Code projects that have .claude/ways/.
+# Outputs one line per project: encoded_name|real_path|way_count|semantic_count
+#
+# Usage:
+#   enumerate_projects | while IFS='|' read -r encoded path way_count sem_count; do
+#     ...
+#   done
+enumerate_projects() {
+  local projects_dir="${HOME}/.claude/projects"
+  [[ -d "$projects_dir" ]] || return
+
+  # Dedup: multiple encoded dirs may resolve to the same repo root
+  # (e.g., project invoked from a subdirectory walks up to the same .claude/ways/)
+  local _seen_paths=""
+
+  while IFS= read -r projdir; do
+    local encoded
+    encoded=$(basename "$projdir")
+    local project_path
+    project_path=$(resolve_project_path "$encoded")
+
+    # Fallback: if no sessions-index.json, greedily resolve against filesystem.
+    # Splits encoded path on -, tries each segment as a directory separator
+    # or part of a hyphenated name. Handles github-manager, platform-ops, etc.
+    if [[ -z "$project_path" ]]; then
+      project_path=$(_resolve_encoded_path "$encoded")
+    fi
+    [[ -z "$project_path" ]] && continue
+
+    # Find .claude/ways/ — may be at projectPath or a parent directory.
+    # Claude Code's projectPath points to where it was invoked, which may
+    # be a subdirectory of the repo root where .claude/ways/ lives.
+    local ways_dir=""
+    local check="$project_path"
+    while [[ "$check" != "/" && "$check" != "$HOME" ]]; do
+      if [[ -d "${check}/.claude/ways" ]]; then
+        ways_dir="${check}/.claude/ways"
+        project_path="$check"  # update to the repo root
+        break
+      fi
+      check=$(dirname "$check")
+    done
+    [[ -z "$ways_dir" ]] && continue
+
+    # Dedup: skip if we already emitted this project path
+    if echo "$_seen_paths" | grep -qF "$project_path"; then
+      continue
+    fi
+    _seen_paths="${_seen_paths}${project_path}
+"
+
+    local way_count
+    way_count=$(find "$ways_dir" -name "way.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+    [[ $way_count -eq 0 ]] && continue
+
+    # Count semantic ways (have both description and vocabulary)
+    local sem_count=0
+    while IFS= read -r wf; do
+      local fm
+      fm=$(awk 'NR==1 && /^---$/{p=1;next} p && /^---$/{exit} p{print}' "$wf")
+      if echo "$fm" | grep -q '^description:' && echo "$fm" | grep -q '^vocabulary:'; then
+        sem_count=$((sem_count + 1))
+      fi
+    done < <(find "$ways_dir" -name "way.md" -type f 2>/dev/null)
+
+    echo "${encoded}|${project_path}|${way_count}|${sem_count}"
+  done < <(find "$projects_dir" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)
+}

--- a/hooks/ways/embed-status.sh
+++ b/hooks/ways/embed-status.sh
@@ -2,7 +2,7 @@
 # Embedding engine status — health dashboard for ADR-108/109
 #
 # Reports: engine in use, binary/model/corpus state, way counts,
-# per-project inclusion status, and staleness indicators.
+# per-project inclusion status, staleness indicators, and manifest state.
 #
 # Usage: embed-status [--json]
 
@@ -11,9 +11,22 @@ set -euo pipefail
 XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
 WAYS_DIR="${HOME}/.claude/hooks/ways"
 WAYS_JSON="${HOME}/.claude/ways.json"
+MANIFEST="${XDG_WAY}/embed-manifest.json"
+PROJECTS_DIR="${HOME}/.claude/projects"
 
-# --- Output mode ---
+# --- Args ---
 JSON=false
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  B='' D='' C='' R=''
+  if [[ -t 1 ]]; then B='\033[1m' D='\033[2m' C='\033[0;36m' R='\033[0m'; fi
+  echo -e "${B}embed-status${R} — Embedding engine health dashboard"
+  echo ""
+  echo -e "  ${C}Usage:${R}  embed-status [--json]"
+  echo ""
+  echo -e "  ${D}Reports engine, binary, model, corpus, manifest state,${R}"
+  echo -e "  ${D}per-project inclusion/staleness, and way counts.${R}"
+  exit 0
+fi
 [[ "${1:-}" == "--json" ]] && JSON=true
 
 # --- Colors (disabled for JSON or non-terminal) ---
@@ -83,55 +96,91 @@ fi
 
 # --- Global ways ---
 GLOBAL_WAY_COUNT=$(find "$WAYS_DIR" -name "way.md" -type f 2>/dev/null | wc -l)
-# Count semantic ways (have both description and vocabulary in frontmatter)
 SEMANTIC_WAY_COUNT=0
 while IFS= read -r wf; do
   fm=$(awk 'NR==1 && /^---$/{p=1;next} p && /^---$/{exit} p{print}' "$wf")
   echo "$fm" | grep -q '^description:' && echo "$fm" | grep -q '^vocabulary:' && SEMANTIC_WAY_COUNT=$((SEMANTIC_WAY_COUNT + 1))
 done < <(find "$WAYS_DIR" -name "way.md" -type f 2>/dev/null)
 
-# --- Content hash (for staleness) ---
-GLOBAL_HASH=""
-if command -v sha256sum &>/dev/null; then
-  GLOBAL_HASH=$(find "$WAYS_DIR" -name "way.md" -type f -exec sha256sum {} + 2>/dev/null | sort | sha256sum | cut -d' ' -f1)
-elif command -v shasum &>/dev/null; then
-  GLOBAL_HASH=$(find "$WAYS_DIR" -name "way.md" -type f -exec shasum -a 256 {} + 2>/dev/null | sort | shasum -a 256 | cut -d' ' -f1)
+# --- Shared library ---
+EMBED_LIB="${HOME}/.claude/hooks/ways/embed-lib.sh"
+# shellcheck source=embed-lib.sh
+source "$EMBED_LIB"
+
+GLOBAL_HASH=$(content_hash "$WAYS_DIR")
+
+# Check global staleness against manifest
+GLOBAL_STALE=false
+MANIFEST_EXISTS=false
+MANIFEST_GLOBAL_HASH=""
+if [[ -f "$MANIFEST" ]] && command -v jq &>/dev/null; then
+  MANIFEST_EXISTS=true
+  MANIFEST_GLOBAL_HASH=$(jq -r '.global_hash // empty' "$MANIFEST" 2>/dev/null)
+  [[ "$MANIFEST_GLOBAL_HASH" != "$GLOBAL_HASH" ]] && GLOBAL_STALE=true
 fi
 
-# --- Project-local ways ---
-# Claude Code encodes project paths in ~/.claude/projects/ by replacing / with -
-# but this encoding is lossy (paths with hyphens can't be decoded). Instead of
-# guessing, we scan each encoded project dir for a .claude/ways/ breadcrumb:
-# each project dir may contain a CLAUDE.md or settings that hint at the real path,
-# but the reliable approach is to try candidate paths.
-PROJECTS_DIR="${HOME}/.claude/projects"
+# --- Project-local ways (enumerate_projects from embed-lib.sh) ---
+# Augments with marker state, staleness, and embedded count per project.
+
 PROJECT_COUNT=0
 PROJECT_WAYS=0
+PROJECT_EMBEDDED=0
 PROJECT_LIST=""
 
-if [[ -d "$PROJECTS_DIR" ]]; then
-  while IFS= read -r projdir; do
-    encoded=$(basename "$projdir")
+while IFS='|' read -r encoded project_path way_count sem_count; do
+    ways_dir="${project_path}/.claude/ways"
 
-    # Try simple decode first (works when path has no hyphens in dir names)
-    candidate=$(echo "$encoded" | sed 's/^-/\//; s/-/\//g')
+    # Check marker state
+    marker="${project_path}/.claude/.ways-embed"
+    if [[ -f "$marker" ]]; then
+      state=$(cat "$marker" 2>/dev/null | tr -d '[:space:]')
+    else
+      state="no-marker"
+    fi
 
-    # Check if decoded path has .claude/ways/ — skip silently if not found
-    # (lossy encoding means some paths won't decode correctly)
-    if [[ -d "${candidate}/.claude/ways" ]]; then
-      count=$(find "${candidate}/.claude/ways" -name "way.md" -type f 2>/dev/null | wc -l)
-      if [[ $count -gt 0 ]]; then
-        PROJECT_COUNT=$((PROJECT_COUNT + 1))
-        PROJECT_WAYS=$((PROJECT_WAYS + count))
-        PROJECT_LIST="${PROJECT_LIST}${candidate}:${count}
-"
+    # Check staleness from manifest
+    stale="unknown"
+    if $MANIFEST_EXISTS; then
+      manifest_hash=$(jq -r --arg k "$encoded" '.projects[$k].ways_hash // empty' "$MANIFEST" 2>/dev/null)
+      if [[ -z "$manifest_hash" ]]; then
+        stale="not-in-manifest"
+      else
+        current_hash=$(content_hash "$ways_dir")
+        if [[ "$manifest_hash" == "$current_hash" ]]; then
+          stale="fresh"
+        else
+          stale="stale"
+        fi
       fi
     fi
-  done < <(find "$PROJECTS_DIR" -maxdepth 1 -mindepth 1 -type d 2>/dev/null)
-fi
+
+    # Count embedded ways in corpus for this project
+    embedded=0
+    if $CORPUS_EXISTS; then
+      embedded=$(grep -c "\"${encoded}/" "$CORPUS" 2>/dev/null || true)
+      embedded=${embedded:-0}
+    fi
+
+    PROJECT_COUNT=$((PROJECT_COUNT + 1))
+    PROJECT_WAYS=$((PROJECT_WAYS + way_count))
+    PROJECT_EMBEDDED=$((PROJECT_EMBEDDED + embedded))
+    PROJECT_LIST="${PROJECT_LIST}${project_path}|${way_count}|${sem_count}|${state}|${stale}|${embedded}
+"
+
+done < <(enumerate_projects || true)
 
 # --- JSON output ---
 if $JSON; then
+  PROJ_ARRAY=$(echo "$PROJECT_LIST" | awk -F'|' '
+    BEGIN { printf "["; n=0 }
+    NF >= 6 && $1 != "" {
+      if (n > 0) printf ","
+      printf "{\"path\":\"%s\",\"ways\":%d,\"semantic\":%d,\"marker\":\"%s\",\"staleness\":\"%s\",\"embedded\":%d}", $1, $2+0, $3+0, $4, $5, $6+0
+      n++
+    }
+    END { printf "]" }
+  ')
+
   cat <<ENDJSON
 {
   "engine": "$(echo "$ENGINE" | sed 's/"/\\"/g')",
@@ -152,12 +201,19 @@ if $JSON; then
     "embedded": $CORPUS_EMBEDDED,
     "size": "$CORPUS_SIZE"
   },
+  "manifest": {
+    "path": "$MANIFEST",
+    "exists": $MANIFEST_EXISTS
+  },
   "global_ways": $GLOBAL_WAY_COUNT,
   "semantic_ways": $SEMANTIC_WAY_COUNT,
   "global_hash": "$GLOBAL_HASH",
+  "global_stale": $GLOBAL_STALE,
   "projects": {
     "count": $PROJECT_COUNT,
-    "ways": $PROJECT_WAYS
+    "ways": $PROJECT_WAYS,
+    "embedded": $PROJECT_EMBEDDED,
+    "details": $PROJ_ARRAY
   }
 }
 ENDJSON
@@ -199,23 +255,51 @@ else
   echo -e "  Corpus:  ${RED}not generated${RESET}  ${DIM}(run: make setup)${RESET}"
 fi
 
+# Manifest
+echo ""
+if $MANIFEST_EXISTS; then
+  echo -e "  Manifest:  ${GREEN}${MANIFEST}${RESET}"
+else
+  echo -e "  Manifest:  ${YELLOW}not found${RESET}  ${DIM}(run: make corpus)${RESET}"
+fi
+
 # Global ways
 echo ""
 echo -e "  ${BOLD}Global ways:${RESET}  ${GLOBAL_WAY_COUNT} total, ${SEMANTIC_WAY_COUNT} semantic"
-if $CORPUS_EXISTS && [[ $SEMANTIC_WAY_COUNT -ne $CORPUS_WAYS ]]; then
-  echo -e "  ${YELLOW}Corpus has ${CORPUS_WAYS} entries but ${SEMANTIC_WAY_COUNT} semantic ways exist — regen needed${RESET}"
+if $GLOBAL_STALE; then
+  echo -e "  ${YELLOW}Global ways are stale — corpus needs regen${RESET}"
+  echo -e "  ${DIM}Run: make corpus${RESET}"
+elif $CORPUS_EXISTS && [[ $SEMANTIC_WAY_COUNT -gt $CORPUS_WAYS ]]; then
+  echo -e "  ${YELLOW}Corpus has ${CORPUS_WAYS} entries but ${SEMANTIC_WAY_COUNT}+ semantic ways exist — regen needed${RESET}"
   echo -e "  ${DIM}Run: make corpus${RESET}"
 fi
 
 # Project-local ways
 if [[ $PROJECT_COUNT -gt 0 ]]; then
   echo ""
-  echo -e "  ${BOLD}Project ways:${RESET}  ${PROJECT_WAYS} ways across ${PROJECT_COUNT} projects"
-  echo "$PROJECT_LIST" | while IFS=: read -r path count; do
+  echo -e "  ${BOLD}Project ways:${RESET}  ${PROJECT_WAYS} ways across ${PROJECT_COUNT} projects (${PROJECT_EMBEDDED} embedded)"
+  echo "$PROJECT_LIST" | while IFS='|' read -r path wcount scount state stale embedded; do
     [[ -z "$path" ]] && continue
-    echo -e "    ${DIM}${path}${RESET}  ${count} ways"
+    display_path=$(echo "$path" | sed "s|^$HOME|~|")
+
+    # Status indicator
+    case "$state" in
+      include)      state_icon="${GREEN}included${RESET}" ;;
+      disinclude)   state_icon="${YELLOW}disincluded${RESET}" ;;
+      no-marker)    state_icon="${DIM}no marker${RESET}" ;;
+      *)            state_icon="${DIM}${state}${RESET}" ;;
+    esac
+
+    # Staleness indicator
+    case "$stale" in
+      fresh)            stale_icon="${GREEN}fresh${RESET}" ;;
+      stale)            stale_icon="${YELLOW}stale${RESET}" ;;
+      not-in-manifest)  stale_icon="${YELLOW}not embedded${RESET}" ;;
+      *)                stale_icon="${DIM}${stale}${RESET}" ;;
+    esac
+
+    echo -e "    ${display_path}  ${wcount} ways (${scount} semantic)  ${state_icon}  ${stale_icon}"
   done
-  echo -e "  ${DIM}(project ways not yet embedded — see ADR-109)${RESET}"
 fi
 
 # Hash

--- a/hooks/ways/lint-ways.sh
+++ b/hooks/ways/lint-ways.sh
@@ -2,7 +2,8 @@
 # Way frontmatter linter and fixer
 #
 # Usage:
-#   lint-ways.sh                     # lint all ways (global + project)
+#   lint-ways.sh                     # lint all ways (global + current project)
+#   lint-ways.sh --all-projects      # lint all ways (global + every tracked project)
 #   lint-ways.sh <path>              # lint ways under a specific directory
 #   lint-ways.sh --fix               # show suggested fixes (does not auto-apply)
 #   lint-ways.sh --schema            # print the frontmatter schema
@@ -15,20 +16,41 @@ set -uo pipefail
 
 WAYS_DIR="${HOME}/.claude/hooks/ways"
 SCHEMA_FILE="${WAYS_DIR}/frontmatter-schema.yaml"
+
+# Colors (disabled for non-terminal)
+if [[ -t 1 ]]; then
+  GREEN='\033[0;32m' YELLOW='\033[1;33m' RED='\033[0;31m'
+  CYAN='\033[0;36m' DIM='\033[2m' BOLD='\033[1m' RESET='\033[0m'
+else
+  GREEN='' YELLOW='' RED='' CYAN='' DIM='' BOLD='' RESET=''
+fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
 
 MODE="lint"
 FIX=false
 STRICT=false
+ALL_PROJECTS=false
 TARGET=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --fix)    FIX=true; shift ;;
-        --strict) STRICT=true; shift ;;
-        --schema) MODE="schema"; shift ;;
+        --fix)          FIX=true; shift ;;
+        --strict)       STRICT=true; shift ;;
+        --schema)       MODE="schema"; shift ;;
+        --all-projects) ALL_PROJECTS=true; shift ;;
         --help|-h)
-            sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
+            B='' D='' C='' R=''
+            if [[ -t 1 ]]; then B='\033[1m' D='\033[2m' C='\033[0;36m' R='\033[0m'; fi
+            echo -e "${B}lint-ways${R} — Way frontmatter linter"
+            echo ""
+            echo -e "  ${C}Usage:${R}  lint-ways.sh [options] [path]"
+            echo ""
+            echo -e "  ${D}(default)        Lint global + current project ways${R}"
+            echo -e "  ${D}--all-projects   Lint global + every tracked project${R}"
+            echo -e "  ${D}--fix            Show suggested fixes (does not auto-apply)${R}"
+            echo -e "  ${D}--strict         Check recommended fields${R}"
+            echo -e "  ${D}--schema         Print the frontmatter schema${R}"
+            echo -e "  ${D}<path>           Lint ways under a specific directory${R}"
             exit 0
             ;;
         *)  TARGET="$1"; shift ;;
@@ -39,7 +61,7 @@ done
 # Regenerate ways-corpus.jsonl before linting so IDF is current.
 # Only runs if the generator script exists.
 CORPUS_GEN="${HOME}/.claude/tools/way-match/generate-corpus.sh"
-if [[ -x "$CORPUS_GEN" && "$MODE" == "lint" ]]; then
+if [[ -x "$CORPUS_GEN" && "$MODE" == "lint" && -z "${GENERATE_CORPUS_RUNNING:-}" ]]; then
     bash "$CORPUS_GEN" --quiet "$WAYS_DIR" 2>/dev/null
 fi
 
@@ -143,7 +165,7 @@ lint_file() {
     frontmatter=$(awk 'NR==1 && /^---$/{p=1; next} p && /^---$/{exit} p{print}' "$filepath")
 
     [[ -z "$frontmatter" ]] && {
-        echo "  ERROR: $relpath — no YAML frontmatter"
+        echo -e "  ${RED}ERROR:${RESET} $relpath — no YAML frontmatter"
         ((ERRORS++))
         return
     }
@@ -164,10 +186,10 @@ lint_file() {
     local multiline_fields
     multiline_fields=$(echo "$frontmatter" | awk '/^[a-z_]+: *[>|] *$/{gsub(/:.*/, ""); print}')
     for mlf in $multiline_fields; do
-        echo "  ERROR: $relpath — '$mlf' uses multi-line YAML (> or |) which the trigger pipeline cannot parse. Use a single line."
+        echo -e "  ${RED}ERROR:${RESET} $relpath — '$mlf' uses multi-line YAML (> or |) which the trigger pipeline cannot parse. Use a single line."
         ((file_errors++))
         if [[ "$FIX" == "true" ]]; then
-            echo "    fix: collapse '$mlf:' value to a single line"
+            echo -e "    ${DIM}fix: collapse '$mlf:' value to a single line${RESET}"
         fi
     done
 
@@ -180,10 +202,10 @@ lint_file() {
             [[ "$field" == "$valid" ]] && { found=true; break; }
         done
         if [[ "$found" == "false" ]]; then
-            echo "  UNKNOWN: $relpath — unknown field '$field'"
+            echo -e "  ${YELLOW}UNKNOWN:${RESET} $relpath — unknown field '$field'"
             ((file_warnings++))
             if [[ "$FIX" == "true" ]]; then
-                echo "    fix: remove '$field:' line"
+                echo -e "    ${DIM}fix: remove '$field:' line${RESET}"
             fi
         fi
     done
@@ -193,11 +215,11 @@ lint_file() {
     has_desc=$(echo "$frontmatter" | grep -c '^description:' || true)
     has_vocab=$(echo "$frontmatter" | grep -c '^vocabulary:' || true)
     if [[ "$has_desc" -gt 0 && "$has_vocab" -eq 0 ]]; then
-        echo "  WARNING: $relpath — description without vocabulary (semantic matching incomplete)"
+        echo -e "  ${YELLOW}WARNING:${RESET} $relpath — description without vocabulary (semantic matching incomplete)"
         ((file_warnings++))
     fi
     if [[ "$has_vocab" -gt 0 && "$has_desc" -eq 0 ]]; then
-        echo "  WARNING: $relpath — vocabulary without description (semantic matching incomplete)"
+        echo -e "  ${YELLOW}WARNING:${RESET} $relpath — vocabulary without description (semantic matching incomplete)"
         ((file_warnings++))
     fi
 
@@ -205,7 +227,7 @@ lint_file() {
     local thresh
     thresh=$(echo "$frontmatter" | awk '/^threshold:/{gsub(/^threshold: */,"");print;exit}')
     if [[ -n "$thresh" ]] && ! echo "$thresh" | grep -qE '^[0-9]+\.?[0-9]*$'; then
-        echo "  ERROR: $relpath — threshold '$thresh' is not numeric"
+        echo -e "  ${RED}ERROR:${RESET} $relpath — threshold '$thresh' is not numeric"
         ((file_errors++))
     fi
 
@@ -222,7 +244,7 @@ lint_file() {
                 [[ "$s" == "$vs" ]] && { scope_valid=true; break; }
             done
             if [[ "$scope_valid" == "false" ]]; then
-                echo "  ERROR: $relpath — invalid scope '$s' (valid: $VALID_SCOPES)"
+                echo -e "  ${RED}ERROR:${RESET} $relpath — invalid scope '$s' (valid: $VALID_SCOPES)"
                 ((file_errors++))
             fi
         done
@@ -237,7 +259,7 @@ lint_file() {
             [[ "$macro_val" == "$vm" ]] && { macro_valid=true; break; }
         done
         if [[ "$macro_valid" == "false" ]]; then
-            echo "  ERROR: $relpath — invalid macro '$macro_val' (valid: $VALID_MACROS)"
+            echo -e "  ${RED}ERROR:${RESET} $relpath — invalid macro '$macro_val' (valid: $VALID_MACROS)"
             ((file_errors++))
         fi
     fi
@@ -251,7 +273,7 @@ lint_file() {
             [[ "$trigger_val" == "$vt" ]] && { trigger_valid=true; break; }
         done
         if [[ "$trigger_valid" == "false" ]]; then
-            echo "  ERROR: $relpath — invalid trigger '$trigger_val' (valid: $VALID_TRIGGERS)"
+            echo -e "  ${RED}ERROR:${RESET} $relpath — invalid trigger '$trigger_val' (valid: $VALID_TRIGGERS)"
             ((file_errors++))
         fi
     fi
@@ -268,7 +290,7 @@ lint_file() {
                 [[ "$wf" == "$valid_wf" ]] && { wf_valid=true; break; }
             done
             if [[ "$wf_valid" == "false" ]]; then
-                echo "  UNKNOWN: $relpath — unknown when: sub-field '$wf'"
+                echo -e "  ${YELLOW}UNKNOWN:${RESET} $relpath — unknown when: sub-field '$wf'"
                 ((file_warnings++))
             fi
         done
@@ -279,7 +301,7 @@ lint_file() {
         if [[ -n "$when_project" ]]; then
             local expanded="${when_project/#\~/$HOME}"
             if [[ ! -d "$expanded" ]]; then
-                echo "  WARNING: $relpath — when.project path '$when_project' does not exist"
+                echo -e "  ${YELLOW}WARNING:${RESET} $relpath — when.project path '$when_project' does not exist"
                 ((file_warnings++))
             fi
         fi
@@ -291,7 +313,7 @@ lint_file() {
         local has_pattern
         has_pattern=$(echo "$frontmatter" | grep -c '^pattern:' || true)
         if [[ "$has_pattern" -gt 0 && "$has_desc" -eq 0 && "$has_vocab" -eq 0 ]]; then
-            echo "  RECOMMEND: $relpath — regex-only matching; add description + vocabulary for natural language coverage"
+            echo -e "  ${CYAN}RECOMMEND:${RESET} $relpath — regex-only matching; add description + vocabulary for natural language coverage"
             ((file_warnings++))
         fi
 
@@ -308,10 +330,10 @@ lint_file() {
                 continue
             fi
             if ! echo "$frontmatter" | grep -q "^${rec}:"; then
-                echo "  RECOMMEND: $relpath — missing recommended field '$rec'"
+                echo -e "  ${CYAN}RECOMMEND:${RESET} $relpath — missing recommended field '$rec'"
                 ((file_warnings++))
                 if [[ "$FIX" == "true" ]]; then
-                    echo "    fix: add '$rec:' with appropriate value"
+                    echo -e "    ${DIM}fix: add '$rec:' with appropriate value${RESET}"
                 fi
             fi
         done
@@ -320,11 +342,11 @@ lint_file() {
     # check.md specific: verify anchor and check sections
     if [[ "$filetype" == "check" ]]; then
         if ! grep -q '^## anchor' "$filepath"; then
-            echo "  ERROR: $relpath — check.md missing '## anchor' section"
+            echo -e "  ${RED}ERROR:${RESET} $relpath — check.md missing '## anchor' section"
             ((file_errors++))
         fi
         if ! grep -q '^## check' "$filepath"; then
-            echo "  ERROR: $relpath — check.md missing '## check' section"
+            echo -e "  ${RED}ERROR:${RESET} $relpath — check.md missing '## check' section"
             ((file_errors++))
         fi
     fi
@@ -335,8 +357,9 @@ lint_file() {
 
 # ── Scan ──────────────────────────────────────────────────────────
 
-echo "=== Way Frontmatter Lint ==="
-echo "Schema: $SCHEMA_FILE"
+echo ""
+echo -e "${BOLD}Way Frontmatter Lint${RESET}"
+echo -e "${DIM}Schema: $SCHEMA_FILE${RESET}"
 echo ""
 
 scan_dir() {
@@ -353,22 +376,59 @@ scan_dir() {
     done < <(find "$dir" \( -name "way.md" -o -name "check.md" \) -print0 2>/dev/null | sort -z)
 
     echo ""
-    echo "$label: scanned $count files"
+    echo -e "${DIM}${label}: scanned $count files${RESET}"
 }
+
+PROJ_SCANNED=0
+PROJ_WITH_WAYS=0
+PROJ_WITH_SEMANTIC=0
+PROJ_TOTAL=0
 
 if [[ -n "$TARGET" ]]; then
     scan_dir "$TARGET" "Target"
+elif $ALL_PROJECTS; then
+    # Scan all tracked projects using shared crawler
+    EMBED_LIB="${WAYS_DIR}/embed-lib.sh"
+    if [[ -f "$EMBED_LIB" ]]; then
+        # shellcheck source=embed-lib.sh
+        source "$EMBED_LIB"
+
+        # Count total projects in ~/.claude/projects/
+        PROJ_TOTAL=$(find "${HOME}/.claude/projects" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+
+        while IFS='|' read -r _encoded project_path way_count sem_count; do
+            display=$(echo "$project_path" | sed "s|^$HOME|~|")
+            scan_dir "${project_path}/.claude/ways" "Project: ${display}"
+            PROJ_SCANNED=$((PROJ_SCANNED + 1))
+            PROJ_WITH_WAYS=$((PROJ_WITH_WAYS + 1))
+            [[ $sem_count -gt 0 ]] && PROJ_WITH_SEMANTIC=$((PROJ_WITH_SEMANTIC + 1))
+        done < <(enumerate_projects || true)
+    fi
+    scan_dir "$WAYS_DIR" "Global"
 else
     if [[ -n "$PROJECT_DIR" && -d "$PROJECT_DIR/.claude/ways" ]]; then
         scan_dir "$PROJECT_DIR/.claude/ways" "Project-local"
+        PROJ_SCANNED=1
+        PROJ_WITH_WAYS=1
     fi
     scan_dir "$WAYS_DIR" "Global"
 fi
 
 echo ""
-echo "════════════════════════════"
-echo "Summary: $ERRORS errors, $WARNINGS warnings"
-echo "════════════════════════════"
+if [[ $ERRORS -gt 0 ]]; then
+  echo -e "${RED}Summary: $ERRORS errors, $WARNINGS warnings${RESET}"
+elif [[ $WARNINGS -gt 0 ]]; then
+  echo -e "${YELLOW}Summary: $ERRORS errors, $WARNINGS warnings${RESET}"
+else
+  echo -e "${GREEN}Summary: $ERRORS errors, $WARNINGS warnings${RESET}"
+fi
+
+if $ALL_PROJECTS && [[ $PROJ_TOTAL -gt 0 ]]; then
+  echo -e "${DIM}Projects: ${PROJ_TOTAL} tracked, ${PROJ_WITH_WAYS} with ways, ${PROJ_WITH_SEMANTIC} with semantic ways${RESET}"
+elif [[ $PROJ_SCANNED -gt 0 ]]; then
+  echo -e "${DIM}Projects: ${PROJ_SCANNED} scanned${RESET}"
+fi
+echo ""
 
 [[ $ERRORS -gt 0 ]] && exit 1
 exit 0

--- a/hooks/ways/stats.sh
+++ b/hooks/ways/stats.sh
@@ -9,6 +9,20 @@
 #   --projects   Per-project dashboard (sessions, memory, way fires)
 #   --json       Machine-readable output
 
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  B='' D='' C='' R=''
+  if [[ -t 1 ]]; then B='\033[1m' D='\033[2m' C='\033[0;36m' R='\033[0m'; fi
+  echo -e "${B}ways-stats${R} — Way firing statistics and project dashboard"
+  echo ""
+  echo -e "  ${C}Usage:${R}  ways-stats [--days N] [--project PATH] [--projects] [--json]"
+  echo ""
+  echo -e "  ${D}--days N       Show last N days (default: all)${R}"
+  echo -e "  ${D}--project PATH Filter to specific project${R}"
+  echo -e "  ${D}--projects     Per-project dashboard mode${R}"
+  echo -e "  ${D}--json         Machine-readable output${R}"
+  exit 0
+fi
+
 STATS_FILE="${HOME}/.claude/stats/events.jsonl"
 PROJECTS_DIR="${HOME}/.claude/projects"
 

--- a/lint-ways
+++ b/lint-ways
@@ -1,0 +1,1 @@
+hooks/ways/lint-ways.sh

--- a/settings.json
+++ b/settings.json
@@ -66,6 +66,10 @@
           {
             "type": "command",
             "command": "${HOME}/.claude/hooks/check-config-updates.sh"
+          },
+          {
+            "type": "command",
+            "command": "${HOME}/.claude/hooks/ways/check-embedding-staleness.sh"
           }
         ]
       },

--- a/tools/way-match/generate-corpus.sh
+++ b/tools/way-match/generate-corpus.sh
@@ -1,96 +1,232 @@
 #!/bin/bash
 # Generate ways-corpus.jsonl from all semantic way.md files
 #
-# Scans for way.md files with description+vocabulary frontmatter,
-# extracts fields, and emits one JSON line per way.
+# Scans global ways and project-local ways into a unified corpus.
+# Extracts frontmatter fields and emits one JSON line per way.
 #
 # Output is a generated cache in XDG_CACHE_HOME — not tracked in git.
 # Runtime scanners read it; regen happens via `make setup` or `make test`.
 #
+# After generation, writes embed-manifest.json with content hashes for
+# staleness detection (ADR-109). The manifest records what was embedded
+# so session-start checks can detect when regen is needed.
+#
 # Usage: generate-corpus.sh [--quiet] [ways-dir] [output-file]
 #   --quiet:     suppress progress output (for use in test/lint pipelines)
-#   ways-dir:    directory to scan (default: ~/.claude/hooks/ways)
+#   ways-dir:    directory to scan for global ways (default: ~/.claude/hooks/ways)
 #   output-file: where to write JSONL (default: ~/.cache/claude-ways/user/ways-corpus.jsonl)
 
 QUIET=false
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  B='' D='' C='' R=''
+  if [[ -t 1 ]]; then B='\033[1m' D='\033[2m' C='\033[0;36m' R='\033[0m'; fi
+  echo -e "${B}embed-corpus${R} — Generate unified ways embedding corpus"
+  echo ""
+  echo -e "  ${C}Usage:${R}  embed-corpus [--quiet] [ways-dir] [output-file]"
+  echo ""
+  echo -e "  ${D}--quiet       Suppress progress output (for pipelines)${R}"
+  echo -e "  ${D}ways-dir      Global ways directory (default: ~/.claude/hooks/ways)${R}"
+  echo -e "  ${D}output-file   Corpus path (default: ~/.cache/claude-ways/user/ways-corpus.jsonl)${R}"
+  echo ""
+  echo -e "  ${D}Scans global + project-local ways, embeds into single corpus,${R}"
+  echo -e "  ${D}writes embed-manifest.json for staleness detection.${R}"
+  exit 0
+fi
 [[ "${1:-}" == "--quiet" ]] && { QUIET=true; shift; }
 
 WAYS_DIR="${1:-${HOME}/.claude/hooks/ways}"
 XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
 OUTPUT="${2:-${XDG_WAY}/ways-corpus.jsonl}"
+PROJECTS_DIR="${HOME}/.claude/projects"
+LINT_SCRIPT="${HOME}/.claude/hooks/ways/lint-ways.sh"
 mkdir -p "$XDG_WAY"
 
 log() { $QUIET || echo "$@" >&2; }
+
+# Guard against infinite recursion with lint-ways.sh
+export GENERATE_CORPUS_RUNNING=1
 
 # Temp file for atomic write
 TMPFILE="${OUTPUT}.tmp.$$"
 trap 'rm -f "$TMPFILE"' EXIT
 
+# ── Shared library ───────────────────────────────────────────────
+# Provides: content_hash, resolve_project_path, json_escape
+EMBED_LIB="${HOME}/.claude/hooks/ways/embed-lib.sh"
+# shellcheck source=../../hooks/ways/embed-lib.sh
+source "$EMBED_LIB"
+
+# ── Scan a ways directory into corpus ────────────────────────────
+# Args: $1=ways_dir $2=id_prefix (empty for global, "encoded-path/" for project)
+# Appends to $TMPFILE, increments $count
+scan_ways_dir() {
+  local scan_dir="$1"
+  local id_prefix="$2"
+
+  while IFS= read -r wayfile; do
+    # Extract frontmatter block
+    frontmatter=$(awk 'NR==1 && /^---$/{p=1;next} p && /^---$/{exit} p{print}' "$wayfile")
+
+    # Extract fields
+    description=$(echo "$frontmatter" | awk '/^description:/{gsub(/^description: */,"");print;exit}')
+    vocabulary=$(echo "$frontmatter" | awk '/^vocabulary:/{gsub(/^vocabulary: */,"");print;exit}')
+    threshold=$(echo "$frontmatter" | awk '/^threshold:/{gsub(/^threshold: */,"");print;exit}')
+    embed_threshold=$(echo "$frontmatter" | awk '/^embed_threshold:/{gsub(/^embed_threshold: */,"");print;exit}')
+
+    # Skip ways without semantic fields
+    [[ -z "$description" || -z "$vocabulary" ]] && continue
+
+    # Derive id from path
+    relpath="${wayfile#$scan_dir/}"
+    id="${id_prefix}${relpath%/way.md}"
+
+    # Escape JSON strings (handle quotes and backslashes)
+    desc_escaped=$(printf '%s' "$description" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    vocab_escaped=$(printf '%s' "$vocabulary" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    thresh_val="${threshold:-2.0}"
+    embed_thresh_val="${embed_threshold:-0.35}"
+
+    printf '{"id":"%s","description":"%s","vocabulary":"%s","threshold":%s,"embed_threshold":%s}\n' \
+      "$id" "$desc_escaped" "$vocab_escaped" "$thresh_val" "$embed_thresh_val" >> "$TMPFILE"
+
+    count=$((count + 1))
+
+  done < <(find "$scan_dir" -name "way.md" -type f | sort)
+
+  # Also scan for way-*.md (future locale files)
+  while IFS= read -r wayfile; do
+    frontmatter=$(awk 'NR==1 && /^---$/{p=1;next} p && /^---$/{exit} p{print}' "$wayfile")
+    description=$(echo "$frontmatter" | awk '/^description:/{gsub(/^description: */,"");print;exit}')
+    vocabulary=$(echo "$frontmatter" | awk '/^vocabulary:/{gsub(/^vocabulary: */,"");print;exit}')
+    threshold=$(echo "$frontmatter" | awk '/^threshold:/{gsub(/^threshold: */,"");print;exit}')
+    embed_threshold=$(echo "$frontmatter" | awk '/^embed_threshold:/{gsub(/^embed_threshold: */,"");print;exit}')
+
+    [[ -z "$description" || -z "$vocabulary" ]] && continue
+
+    relpath="${wayfile#$scan_dir/}"
+    id="${id_prefix}${relpath%.md}"
+
+    desc_escaped=$(printf '%s' "$description" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    vocab_escaped=$(printf '%s' "$vocabulary" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    thresh_val="${threshold:-2.0}"
+    embed_thresh_val="${embed_threshold:-0.35}"
+
+    printf '{"id":"%s","description":"%s","vocabulary":"%s","threshold":%s,"embed_threshold":%s}\n' \
+      "$id" "$desc_escaped" "$vocab_escaped" "$thresh_val" "$embed_thresh_val" >> "$TMPFILE"
+
+    count=$((count + 1))
+
+  done < <(find "$scan_dir" -name "way-*.md" -type f 2>/dev/null | sort)
+}
+
+# resolve_project_path provided by embed-lib.sh
+
+# ── .ways-embed marker management ────────────────────────────────
+# Marker at <project>/.claude/.ways-embed controls inclusion.
+# States: "include" (default on first discovery), "disinclude" (opt-out)
+check_ways_embed_marker() {
+  local project_path="$1"
+  local marker="${project_path}/.claude/.ways-embed"
+  local ways_dir="${project_path}/.claude/ways"
+
+  # Count semantic ways (description + vocabulary)
+  local semantic_count=0
+  while IFS= read -r wf; do
+    local fm
+    fm=$(awk 'NR==1 && /^---$/{p=1;next} p && /^---$/{exit} p{print}' "$wf")
+    if echo "$fm" | grep -q '^description:' && echo "$fm" | grep -q '^vocabulary:'; then
+      semantic_count=$((semantic_count + 1))
+    fi
+  done < <(find "$ways_dir" -name "way.md" -type f 2>/dev/null)
+
+  if [[ -f "$marker" ]]; then
+    local state
+    state=$(cat "$marker" 2>/dev/null | tr -d '[:space:]')
+    if [[ "$state" == "disinclude" ]]; then
+      if [[ $semantic_count -gt 0 ]]; then
+        log "  WARNING: ${project_path} has ${semantic_count} semantic ways but is disincluded"
+      fi
+      echo "disinclude"
+      return
+    fi
+    # Any other value (include, empty, etc) → include
+    echo "include"
+    return
+  fi
+
+  # No marker: create one if valid semantic ways exist
+  if [[ $semantic_count -gt 0 ]]; then
+    # Ensure .claude/ exists (it should, since ways/ is under it)
+    mkdir -p "${project_path}/.claude" 2>/dev/null
+    echo "include" > "$marker" 2>/dev/null
+    log "  Created .ways-embed marker: ${project_path}/.claude/.ways-embed"
+    echo "include"
+  else
+    echo "skip"
+  fi
+}
+
+# ── Main: scan global ways ───────────────────────────────────────
+
 count=0
+global_count=0
+project_total=0
 
-while IFS= read -r wayfile; do
-  # Extract frontmatter block
-  frontmatter=$(awk 'NR==1 && /^---$/{p=1;next} p && /^---$/{exit} p{print}' "$wayfile")
+log "Scanning global ways: ${WAYS_DIR}"
+scan_ways_dir "$WAYS_DIR" ""
+global_count=$count
 
-  # Extract fields
-  description=$(echo "$frontmatter" | awk '/^description:/{gsub(/^description: */,"");print;exit}')
-  vocabulary=$(echo "$frontmatter" | awk '/^vocabulary:/{gsub(/^vocabulary: */,"");print;exit}')
-  threshold=$(echo "$frontmatter" | awk '/^threshold:/{gsub(/^threshold: */,"");print;exit}')
-  embed_threshold=$(echo "$frontmatter" | awk '/^embed_threshold:/{gsub(/^embed_threshold: */,"");print;exit}')
+GLOBAL_HASH=$(content_hash "$WAYS_DIR")
+log "Global ways: ${global_count} (hash: ${GLOBAL_HASH:0:16}...)"
 
-  # Skip ways without semantic fields
-  [[ -z "$description" || -z "$vocabulary" ]] && continue
+# ── Scan project-local ways ──────────────────────────────────────
+# Uses enumerate_projects from embed-lib.sh to find all projects with ways.
+# For each: check marker, lint, embed if included.
 
-  # Derive id from path: hooks/ways/softwaredev/code/security/way.md → softwaredev/code/security
-  relpath="${wayfile#$WAYS_DIR/}"
-  id="${relpath%/way.md}"
+MANIFEST_PROJECTS=""  # Accumulates JSON fragments for manifest
 
-  # Escape JSON strings (handle quotes and backslashes)
-  desc_escaped=$(printf '%s' "$description" | sed 's/\\/\\\\/g; s/"/\\"/g')
-  vocab_escaped=$(printf '%s' "$vocabulary" | sed 's/\\/\\\\/g; s/"/\\"/g')
-  thresh_val="${threshold:-2.0}"
-  embed_thresh_val="${embed_threshold:-0.35}"
+while IFS='|' read -r encoded project_path way_count sem_count; do
+  ways_dir="${project_path}/.claude/ways"
 
-  printf '{"id":"%s","description":"%s","vocabulary":"%s","threshold":%s,"embed_threshold":%s}\n' \
-    "$id" "$desc_escaped" "$vocab_escaped" "$thresh_val" "$embed_thresh_val" >> "$TMPFILE"
+  # Check .ways-embed marker
+  marker_state=$(check_ways_embed_marker "$project_path")
+  [[ "$marker_state" == "disinclude" || "$marker_state" == "skip" ]] && continue
 
-  count=$((count + 1))
+  # Lint gate: project ways must pass linting to be embedded
+  # GENERATE_CORPUS_RUNNING (exported above) prevents lint-ways.sh from
+  # calling generate-corpus.sh again (infinite recursion).
+  if [[ -x "$LINT_SCRIPT" ]]; then
+    if ! bash "$LINT_SCRIPT" "$ways_dir" >/dev/null 2>&1; then
+      log "  SKIP: ${project_path} — ways failed linting"
+      continue
+    fi
+  fi
 
-done < <(find "$WAYS_DIR" -name "way.md" -type f | sort)
+  # Scan project ways into corpus with encoded path prefix
+  local_before=$count
+  scan_ways_dir "$ways_dir" "${encoded}/"
+  local_count=$((count - local_before))
 
-# Also scan for way-*.md (future locale files)
-while IFS= read -r wayfile; do
-  frontmatter=$(awk 'NR==1 && /^---$/{p=1;next} p && /^---$/{exit} p{print}' "$wayfile")
-  description=$(echo "$frontmatter" | awk '/^description:/{gsub(/^description: */,"");print;exit}')
-  vocabulary=$(echo "$frontmatter" | awk '/^vocabulary:/{gsub(/^vocabulary: */,"");print;exit}')
-  threshold=$(echo "$frontmatter" | awk '/^threshold:/{gsub(/^threshold: */,"");print;exit}')
-  embed_threshold=$(echo "$frontmatter" | awk '/^embed_threshold:/{gsub(/^embed_threshold: */,"");print;exit}')
+  if [[ $local_count -gt 0 ]]; then
+    project_total=$((project_total + local_count))
+    local_hash=$(content_hash "$ways_dir")
+    log "  ${project_path}: ${local_count} ways (hash: ${local_hash:0:16}...)"
 
-  [[ -z "$description" || -z "$vocabulary" ]] && continue
-
-  relpath="${wayfile#$WAYS_DIR/}"
-  id="${relpath%.md}"
-
-  desc_escaped=$(printf '%s' "$description" | sed 's/\\/\\\\/g; s/"/\\"/g')
-  vocab_escaped=$(printf '%s' "$vocabulary" | sed 's/\\/\\\\/g; s/"/\\"/g')
-  thresh_val="${threshold:-2.0}"
-  embed_thresh_val="${embed_threshold:-0.35}"
-
-  printf '{"id":"%s","description":"%s","vocabulary":"%s","threshold":%s,"embed_threshold":%s}\n' \
-    "$id" "$desc_escaped" "$vocab_escaped" "$thresh_val" "$embed_thresh_val" >> "$TMPFILE"
-
-  count=$((count + 1))
-
-done < <(find "$WAYS_DIR" -name "way-*.md" -type f 2>/dev/null | sort)
+    # Accumulate manifest entry (JSON fragment, paths escaped)
+    escaped_path=$(json_escape "$project_path")
+    MANIFEST_PROJECTS="${MANIFEST_PROJECTS}$(printf '    "%s": {"path": "%s", "ways_hash": "%s", "ways_count": %d}' \
+      "$encoded" "$escaped_path" "$local_hash" "$local_count")
+"
+  fi
+done < <(enumerate_projects)
 
 # Atomic move
 mv "$TMPFILE" "$OUTPUT"
 
-log "Generated ${OUTPUT}: ${count} ways"
+log "Generated ${OUTPUT}: ${count} ways (${global_count} global, ${project_total} project)"
 
-# Auto-embed: if way-embed binary and model are available, add embedding vectors
-# Check XDG cache first (downloaded), then ~/.claude/bin (built from source)
-XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
+# ── Auto-embed ───────────────────────────────────────────────────
+# If way-embed binary and model are available, add embedding vectors
 if [[ -x "${XDG_WAY}/way-embed" ]]; then
   WAY_EMBED_BIN="${XDG_WAY}/way-embed"
 elif [[ -x "${HOME}/.claude/bin/way-embed" ]]; then
@@ -111,3 +247,25 @@ elif [[ ! -x "$WAY_EMBED_BIN" ]]; then
   log "Tip: install the embedding engine for 98% matching accuracy (vs 91% BM25):"
   log "  cd ~/.claude && make setup"
 fi
+
+# ── Write manifest ───────────────────────────────────────────────
+# Content-addressed manifest for staleness detection (ADR-109).
+# Records hashes so session-start checks can detect when regen is needed.
+MANIFEST="${XDG_WAY}/embed-manifest.json"
+{
+  echo "{"
+  printf '  "global_hash": "%s",\n' "$GLOBAL_HASH"
+  printf '  "global_count": %d,\n' "$global_count"
+  printf '  "total_count": %d,\n' "$count"
+  echo '  "projects": {'
+
+  # Write project entries (trim trailing comma)
+  if [[ -n "$MANIFEST_PROJECTS" ]]; then
+    echo "$MANIFEST_PROJECTS" | sed '/^$/d' | sed '$ ! s/$/,/'
+  fi
+
+  echo "  }"
+  echo "}"
+} > "$MANIFEST"
+
+log "Manifest written: ${MANIFEST}"


### PR DESCRIPTION
## Summary

Extends the embedding engine (ADR-108) to cover project-local ways, closing the matching quality gap between global and project-scope ways.

- **generate-corpus.sh**: Scans all `~/.claude/projects/` for real paths via `sessions-index.json`, lint-gates project ways, manages `.ways-embed` inclusion markers, writes `embed-manifest.json` with content hashes
- **check-embedding-staleness.sh**: New SessionStart hook — checks global + current project hash, triggers background regen if stale
- **embed-status.sh**: Shows manifest state, per-project inclusion/staleness/embedded counts, real paths from manifest
- **embed-corpus**: New CLI symlink for explicit full corpus regen
- Recursion guard between `generate-corpus.sh` ↔ `lint-ways.sh`
- Stale tracking files cleaned up

## Key design decisions (from ADR-109)

- One corpus, one model, one embedding space
- Content-addressed staleness (hashes, not timestamps)
- Session start checks only global + current project (fast); regen sweeps all projects (thorough)
- `.ways-embed` markers: auto-created on first discovery, respect existing include/disinclude

## Test plan

- [x] `make test` — all 15 fixtures pass, 0 FP
- [x] `embed-status` — shows manifest, project inclusion state, staleness
- [x] `embed-status --json` — valid JSON with project details array
- [x] Staleness check: fresh corpus → silent; stale hash → triggers regen
- [x] Recursion guard: `generate-corpus.sh` → `lint-ways.sh` no longer loops
- [x] Project with semantic ways (obsidian-mcp-plugin) → embedded in corpus
- [x] Project without semantic ways (markdown-mixed-media) → skipped, no marker
- [x] Disincluded projects respected, warning emitted