### PR TITLE
feat(ways): mmaid terminal diagram renderer integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,8 @@
 !tools/way-embed/
 !tools/way-embed/*
 !tools/way-embed/llama.cpp
+!tools/mmaid/
+!tools/mmaid/*
 
 # Standalone tools (user-facing CLI utilities)
 !tools/

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,14 @@ help:
 	@echo "  make clean      Remove build artifacts"
 	@echo ""
 
-# Set up the semantic matching engine (embedding binary + model + corpus).
+# Set up the semantic matching engine + tools (embedding, mmaid, corpus).
 # This is the most common target — run it after cloning or pulling.
 setup:
 	@echo "Setting up semantic matching engine..."
 	$(MAKE) -C tools/way-embed setup
+	@echo ""
+	@echo "Setting up mmaid diagram renderer..."
+	@bash tools/mmaid/download-mmaid.sh || echo "  (mmaid optional — skipping)"
 
 # Full first-time install: make hooks executable, build way-match if needed, set up embeddings.
 install: hooks-executable setup

--- a/hooks/ways/softwaredev/architecture/way.md
+++ b/hooks/ways/softwaredev/architecture/way.md
@@ -1,0 +1,16 @@
+---
+description: System design, architecture decisions, and structural thinking about how software is organized
+vocabulary: architecture design system structure decision trade-off pattern component service module layer boundary interface contract dependency coupling cohesion separation concern
+threshold: 2.5
+embed_threshold: 0.30
+scope: agent, subagent
+---
+# Architecture
+
+Children of this way cover structural thinking about software:
+
+| Aspect | Way |
+|--------|-----|
+| Decision records | `architecture/adr` |
+| System design | `architecture/design` |
+| Threat modeling | `architecture/threat-modeling` |

--- a/hooks/ways/softwaredev/code/way.md
+++ b/hooks/ways/softwaredev/code/way.md
@@ -1,0 +1,19 @@
+---
+description: Code quality, testing, security, and performance — the craft of writing and maintaining production code
+vocabulary: code quality clean refactor improve test secure perform optimize review best practice pattern antipattern smell tech debt maintainability readability
+threshold: 2.5
+embed_threshold: 0.30
+scope: agent, subagent
+---
+# Code Craft
+
+Children of this way cover specific aspects of writing and maintaining code:
+
+| Concern | Way |
+|---------|-----|
+| Quality, refactoring, SOLID | `code/quality` |
+| Testing, coverage, fixtures | `code/testing` |
+| Security, auth, secrets | `code/security` |
+| Performance, profiling | `code/performance` |
+| Error handling, boundaries | `code/errors` |
+| Supply chain, dependencies | `code/supplychain` |

--- a/hooks/ways/softwaredev/delivery/way.md
+++ b/hooks/ways/softwaredev/delivery/way.md
@@ -1,0 +1,19 @@
+---
+description: Shipping code — commits, pull requests, releases, migrations, and the path from local changes to production
+vocabulary: ship deliver deploy release commit push merge pull request pr land code review changelog version tag branch workflow ci cd pipeline promote stage production
+threshold: 2.5
+embed_threshold: 0.30
+scope: agent, subagent
+---
+# Delivery
+
+Children of this way cover the journey from local changes to production:
+
+| Stage | Way |
+|-------|-----|
+| Commits, messages | `delivery/commits` |
+| PRs, review, merge | `delivery/github` |
+| Releases, tagging | `delivery/release` |
+| Schema migrations | `delivery/migrations` |
+| Patch creation | `delivery/patches` |
+| Implementation planning | `delivery/implement` |

--- a/hooks/ways/softwaredev/environment/way.md
+++ b/hooks/ways/softwaredev/environment/way.md
@@ -1,0 +1,18 @@
+---
+description: Development environment — configuration, dependencies, debugging, SSH, and build tooling
+vocabulary: environment setup config configure dependency install package build tool debug troubleshoot ssh remote connect server dev local machine workspace
+threshold: 2.5
+embed_threshold: 0.30
+scope: agent, subagent
+---
+# Environment
+
+Children of this way cover the development environment:
+
+| Aspect | Way |
+|--------|-----|
+| Configuration, .env | `environment/config` |
+| Dependencies, packages | `environment/deps` |
+| Debugging | `environment/debugging` |
+| SSH, remote access | `environment/ssh` |
+| Makefile targets | `environment/makefile` |

--- a/hooks/ways/softwaredev/visualization/charts/way.md
+++ b/hooks/ways/softwaredev/visualization/charts/way.md
@@ -3,6 +3,7 @@ description: Render ANSI terminal charts from data — bar, line, sparkline, his
 vocabulary: chart visualize graph sparkline histogram plot trend metric compare bar line table render data display summary distribution hbar spark values series braille ansi terminal
 pattern: chart|visuali[sz]|graph|sparkline|histogram|plot|bar.?chart|trend|metric
 threshold: 2.0
+embed_threshold: 0.32
 scope: agent, subagent
 ---
 # Charts Way

--- a/hooks/ways/softwaredev/visualization/diagrams/way.md
+++ b/hooks/ways/softwaredev/visualization/diagrams/way.md
@@ -1,0 +1,88 @@
+---
+description: Render Mermaid diagrams as terminal art using mmaid — flowcharts, sequences, state machines, ER diagrams, pie charts, gantt, git graphs, and more
+vocabulary: mermaid diagram flowchart sequence state class er entity relationship pie chart gantt timeline kanban mindmap git graph block treemap quadrant render terminal visualize architecture
+pattern: mermaid|diagram|flowchart|sequence.*diagram|state.*diagram|er.*diagram|class.*diagram|gantt|mindmap|visuali[sz]e.*architecture
+threshold: 2.0
+embed_threshold: 0.35
+scope: agent, subagent
+---
+# Terminal Diagrams with mmaid
+
+## mmaid Binary
+
+Location: `${XDG_CACHE_HOME:-~/.cache}/claude-ways/user/mmaid`
+
+If not installed, run: `bash ~/.claude/tools/mmaid/download-mmaid.sh`
+
+## Usage
+
+Pipe Mermaid syntax via stdin:
+
+```bash
+echo 'flowchart LR
+    A[Start] --> B{Decision}
+    B -->|yes| C[Done]
+    B -->|no| D[Retry]' | ~/.cache/claude-ways/user/mmaid -t blueprint
+```
+
+Or render a file: `mmaid diagram.mmd -t slate`
+
+## Choosing the Right Diagram Type
+
+| Content | Use | Not |
+|---------|-----|-----|
+| Request/response flows, temporal sequences | `sequenceDiagram` | flowchart |
+| State transitions, lifecycles | `stateDiagram-v2` | flowchart |
+| Decision logic, branching paths | `flowchart` | sequence |
+| Class/entity relationships | `classDiagram` or `erDiagram` | flowchart |
+| Project schedules | `gantt` | flowchart |
+| Git branching strategies | `gitGraph` | flowchart |
+| Proportional breakdown | `pie` | bar chart |
+| 2x2 matrix/prioritization | `quadrantChart` | flowchart |
+| Hierarchical exploration | `mindmap` | flowchart |
+| Task boards | `kanban` | table |
+| Chronological events | `timeline` | gantt |
+| Data comparison | `xychart-beta` | pie |
+| Proportional area | `treemap-beta` | pie |
+| System architecture | `block-beta` or `flowchart` | sequence |
+
+The most common mistake is using flowchart for everything. If the content has a time axis, it's a sequence diagram. If things transition between states, it's a state diagram.
+
+## Themes
+
+Use `-t THEME` for color. Recommended for terminal readability:
+
+| Theme | Style |
+|-------|-------|
+| `blueprint` | Blue technical drawing (solid backgrounds) |
+| `slate` | Grey neutral (solid backgrounds) |
+| `gruvbox` | Warm retro (solid backgrounds) |
+| `monokai` | Dark with vivid highlights |
+| `mono` | Black and white, no color |
+| `amber` | Retro terminal amber |
+
+Themes with solid backgrounds (`blueprint`, `slate`, `sunset`, `gruvbox`, `monokai`) support depth-based region coloring in subgraphs.
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `-t THEME` | Color theme |
+| `-a` / `--ascii` | ASCII-only (no Unicode) |
+| `-m` / `--markdown` | Wrap output in fenced code block |
+| `--insert FILE:LINE` | Insert output into file after line N |
+| `--padding-x N` | Horizontal node padding (default: 4) |
+| `--padding-y N` | Vertical node padding (default: 2) |
+| `--sharp-edges` | Sharp corners on edge routing |
+| `--demo TYPE` | Show sample diagram |
+
+## When to Use mmaid vs chart-tool
+
+- **mmaid**: Structural diagrams — architecture, flows, relationships, states, schedules
+- **chart-tool**: Data visualization — bar charts, sparklines, histograms, line plots
+
+If the user asks to "visualize" something, consider whether the data is structural (mmaid) or quantitative (chart-tool).
+
+## GitHub Compatibility Note
+
+When writing Mermaid for GitHub markdown (not terminal rendering), use `<br>` instead of `\n` for line breaks in node labels — GitHub's renderer doesn't support `\n`.

--- a/hooks/ways/softwaredev/visualization/way.md
+++ b/hooks/ways/softwaredev/visualization/way.md
@@ -1,0 +1,25 @@
+---
+description: Suggest visual representations when explaining, walking through, or describing systems, flows, and relationships
+vocabulary: walk me through explain how show me describe overview understand flow process step by step architecture workflow pipeline relationship lifecycle sequence interaction dependency diagram visual
+pattern: walk.*through|explain.*how|show.*how|describe.*flow|step.by.step|how.*work|overview.*system
+threshold: 2.5
+embed_threshold: 0.28
+scope: agent, subagent
+---
+# Visualization Opportunity
+
+When explaining something structural — a workflow, a lifecycle, how components interact — consider whether a diagram would communicate it better than prose.
+
+**This is a nudge, not a mandate.** If you're about to write a multi-paragraph textual walkthrough of something spatial or sequential, a visual is probably clearer.
+
+| Signal | Consider |
+|---|---|
+| "Walk me through..." | Sequence diagram or flowchart |
+| "How does X work?" | Flowchart or state diagram |
+| "Show me the data" | Chart (bar, line, histogram) |
+| "What's the relationship between..." | ER diagram or class diagram |
+| Comparing options | Table or chart |
+
+Render to the terminal with the tools in the children of this way:
+- `diagrams/` — `mmaid` for structural diagrams (Mermaid syntax)
+- `charts/` — `chart-tool` for quantitative data (JSON piped)

--- a/tools/mmaid/download-mmaid.sh
+++ b/tools/mmaid/download-mmaid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Download the pre-built mmaid binary for the current platform
+#
+# Detects OS/arch, downloads from GitHub Releases, verifies it runs.
+# Binary is placed at: ${XDG_CACHE_HOME:-~/.cache}/claude-ways/user/mmaid
+#
+# Usage:
+#   download-mmaid.sh [--release TAG]
+
+set -euo pipefail
+
+# Platform detection — mmaid uses GOOS-GOARCH naming
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  GOARCH="amd64" ;;
+  aarch64) GOARCH="arm64" ;;
+  arm64)   GOARCH="arm64" ;;
+  *)       echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+PLATFORM="${OS}-${GOARCH}"
+
+GH_REPO="aaronsb/mmaid-go"
+RELEASE_TAG="${MMAID_RELEASE:-latest}"
+BIN_NAME="mmaid-${PLATFORM}"
+# Windows gets .exe suffix
+[[ "$OS" == "windows" ]] && BIN_NAME="${BIN_NAME}.exe"
+
+XDG_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}"
+OUTPUT_DIR="${XDG_CACHE}/claude-ways/user"
+OUTPUT_FILE="${OUTPUT_DIR}/mmaid"
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release) RELEASE_TAG="$2"; shift 2 ;;
+    --help|-h)
+      B='' D='' C='' R=''
+      if [[ -t 1 ]]; then B='\033[1m' D='\033[2m' C='\033[0;36m' R='\033[0m'; fi
+      echo -e "${B}download-mmaid${R} — Install mmaid terminal diagram renderer"
+      echo ""
+      echo -e "  ${C}Usage:${R}  download-mmaid.sh [--release TAG]"
+      echo ""
+      echo -e "  ${D}--release TAG  GitHub Release tag (default: latest)${R}"
+      echo -e "  ${D}Platform: ${PLATFORM}${R}"
+      echo -e "  ${D}Source: github.com/${GH_REPO}${R}"
+      exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Check if already present and working
+if [[ -x "$OUTPUT_FILE" ]] && "$OUTPUT_FILE" --version >/dev/null 2>&1; then
+  echo "mmaid already installed and working: $OUTPUT_FILE" >&2
+  "$OUTPUT_FILE" --version >&2
+  echo "$OUTPUT_FILE"
+  exit 0
+fi
+
+# Need gh CLI
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found — install it or download mmaid manually:" >&2
+  echo "  https://github.com/${GH_REPO}/releases" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# Find the latest release
+if [[ "$RELEASE_TAG" == "latest" ]]; then
+  RELEASE_TAG=$(gh release list --repo "$GH_REPO" --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null)
+  if [[ -z "$RELEASE_TAG" ]]; then
+    echo "No releases found in ${GH_REPO}" >&2
+    exit 1
+  fi
+fi
+
+echo "Platform: ${PLATFORM}" >&2
+echo "Release:  ${RELEASE_TAG}" >&2
+
+# Check if our platform binary exists in the release
+if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep -q "^${BIN_NAME}$"; then
+  echo "No pre-built binary for ${PLATFORM} in release ${RELEASE_TAG}." >&2
+  echo "Available binaries:" >&2
+  gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null | grep "mmaid-" | sed 's/^/  /' >&2
+  echo "" >&2
+  echo "Build from source: go install github.com/${GH_REPO}/cmd/mmaid@latest" >&2
+  exit 1
+fi
+
+# Download
+echo "Downloading ${BIN_NAME}..." >&2
+gh release download "$RELEASE_TAG" \
+  --repo "$GH_REPO" \
+  --pattern "$BIN_NAME" \
+  --dir "$OUTPUT_DIR" \
+  --clobber
+
+# Install
+PLATFORM_FILE="${OUTPUT_DIR}/${BIN_NAME}"
+chmod +x "$PLATFORM_FILE"
+cp "$PLATFORM_FILE" "$OUTPUT_FILE"
+chmod +x "$OUTPUT_FILE"
+
+# Verify
+if "$OUTPUT_FILE" --version >/dev/null 2>&1; then
+  echo "Installed: $OUTPUT_FILE ($("$OUTPUT_FILE" --version))" >&2
+  ls -lh "$OUTPUT_FILE" >&2
+else
+  echo "WARNING: binary downloaded but won't execute on this platform" >&2
+  echo "Build from source: go install github.com/${GH_REPO}/cmd/mmaid@latest" >&2
+  rm -f "$OUTPUT_FILE" "$PLATFORM_FILE"
+  exit 1
+fi
+
+echo "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary

Integrates [mmaid](https://github.com/aaronsb/mmaid-go) as a downloadable tool module for rendering Mermaid diagrams directly in the terminal. 16 diagram types, 11 color themes, single Go binary.

- **download-mmaid.sh**: Platform-detecting downloader, installs to XDG cache alongside way-embed
- **diagrams way**: Triggers on mermaid/diagram/visualization keywords, teaches diagram type selection and CLI usage
- **Makefile**: `make setup` now includes mmaid (optional, non-blocking if download fails)

Complements chart-tool: mmaid handles structural diagrams (flows, sequences, state machines, ER), chart-tool handles quantitative data (bars, sparklines, histograms).

## Test plan

- [x] `download-mmaid.sh` fetches correct platform binary
- [x] Binary renders all diagram types (flowchart, sequence, state, pie tested)
- [x] Way lints clean
- [x] `make test` passes (15/15)
- [x] Idempotent download (skips if already installed)