### PR TITLE
feat(tools): resolve_tool for system PATH → XDG → build resolution

### DIFF
--- a/hooks/ways/embed-lib.sh
+++ b/hooks/ways/embed-lib.sh
@@ -7,6 +7,7 @@
 #   resolve_project_path — decode Claude Code's lossy path encoding
 #   json_escape          — safe string embedding in JSON
 #   enumerate_projects   — iterate all projects with .claude/ways/
+#   resolve_tool         — find a tool binary (system PATH → XDG → not found)
 
 # Content-addressed hash of all way.md files in a directory.
 # Immune to clock skew, catches uncommitted edits.
@@ -36,6 +37,34 @@ resolve_project_path() {
 # Escape a string for safe JSON embedding (handles quotes and backslashes)
 json_escape() {
   printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+# Resolve a tool binary: system PATH → XDG cache → not found.
+# Returns the path on stdout, empty if not found.
+# Usage: mmaid_bin=$(resolve_tool mmaid)
+resolve_tool() {
+  local name="$1"
+  local xdg_cache="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
+
+  # 1. System PATH (AUR, brew, go install, etc.)
+  if command -v "$name" &>/dev/null; then
+    command -v "$name"
+    return 0
+  fi
+
+  # 2. XDG cache (downloaded by our tooling)
+  if [[ -x "${xdg_cache}/${name}" ]]; then
+    echo "${xdg_cache}/${name}"
+    return 0
+  fi
+
+  # 3. ~/.claude/bin (built from source)
+  if [[ -x "${HOME}/.claude/bin/${name}" ]]; then
+    echo "${HOME}/.claude/bin/${name}"
+    return 0
+  fi
+
+  return 1
 }
 
 # Greedily resolve an encoded path against the filesystem.

--- a/hooks/ways/softwaredev/visualization/diagrams/way.md
+++ b/hooks/ways/softwaredev/visualization/diagrams/way.md
@@ -8,11 +8,27 @@ scope: agent, subagent
 ---
 # Terminal Diagrams with mmaid
 
-## mmaid Binary
+## Finding mmaid
 
-Location: `${XDG_CACHE_HOME:-~/.cache}/claude-ways/user/mmaid`
+Resolution order — use the first one found:
 
-If not installed, run: `bash ~/.claude/tools/mmaid/download-mmaid.sh`
+1. **System PATH**: `mmaid` (installed via AUR, brew, `go install`)
+2. **XDG cache**: `~/.cache/claude-ways/user/mmaid` (downloaded by our tooling)
+3. **Not found**: suggest installation
+
+```bash
+# Check if available (uses resolve_tool from embed-lib.sh)
+source ~/.claude/hooks/ways/embed-lib.sh
+MMAID=$(resolve_tool mmaid)
+
+# Or just check directly
+command -v mmaid || ~/.cache/claude-ways/user/mmaid --version
+```
+
+If not installed:
+- **Arch Linux**: `yay -S mmaid` (AUR, when published)
+- **Go**: `go install github.com/aaronsb/mmaid-go/cmd/mmaid@latest`
+- **Download**: `bash ~/.claude/tools/mmaid/download-mmaid.sh`
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- `resolve_tool` in embed-lib.sh: finds tool binaries across system PATH, XDG cache, and ~/.claude/bin
- Diagrams way updated with installation guidance (AUR, go install, download script)
- Prepares for mmaid AUR package — when installed system-wide, resolve_tool prefers it over XDG copy

## Test plan

- [x] `resolve_tool mmaid` → XDG cache (current)
- [x] `resolve_tool way-match` → ~/.claude/bin
- [x] `resolve_tool nonexistent` → returns 1
- [x] System PATH takes priority when available