### PR TITLE
feat(ways): delivery/release Makefile-first with publishing guidance

### DIFF
--- a/hooks/ways/softwaredev/delivery/release/way.md
+++ b/hooks/ways/softwaredev/delivery/release/way.md
@@ -30,10 +30,22 @@ provenance:
 ---
 # Release Way
 
-## Generate Changelog
+## First: Check for `make release`
+
+Before writing ad-hoc release commands, check if the project has a Makefile with a `release` or `dist` target:
 
 ```bash
-# Commits since last tag
+make help 2>/dev/null | grep -iE 'release|dist|publish|deploy'
+# or just: grep -E '^(release|dist|publish)' Makefile 2>/dev/null
+```
+
+If it exists, **use it**. The Makefile is the canonical release interface — it knows the project's packaging, signing, and publishing steps.
+
+## When There's No `make release`
+
+### Generate Changelog
+
+```bash
 git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || echo "HEAD~20")..HEAD
 ```
 
@@ -46,24 +58,39 @@ Format using Keep a Changelog:
 ### Removed
 ```
 
-## Infer Version Bump
+### Infer Version Bump
 
 From commit messages since last tag:
 - Any `feat!:` or `BREAKING CHANGE` → **major**
 - Any `feat:` → **minor**
 - Only `fix:`, `docs:`, `chore:` → **patch**
 
-## Update Version
+### Update Version
 
 Detect the version file (package.json, Cargo.toml, pyproject.toml, version.txt) and update it.
+
+## Publishing Artifacts
+
+| Destination | How |
+|---|---|
+| GitHub Releases | `gh release create vX.Y.Z --notes-file CHANGELOG.md <binaries>` |
+| npm | `npm publish` (in `make release`) |
+| PyPI | `python -m build && twine upload dist/*` |
+| Cargo | `cargo publish` |
+| AUR | Update PKGBUILD, `makepkg --printsrcinfo > .SRCINFO`, push to AUR |
+| Container registry | `docker build -t repo:vX.Y.Z . && docker push` |
+
+For multi-platform binaries (like way-embed, mmaid), build per-platform, attach all to a single GitHub Release with checksums.
 
 ## This Project
 
 - Annotated tags: `git tag -a vX.Y.Z -m "summary"`
 - Push tags explicitly: `git push origin main --tags`
 - No CI release pipeline — tagging is the release
+- Binary tools: GitHub Releases with per-platform artifacts + `checksums.txt`
 
 ## Do Not
 
 - Explain what semantic versioning is — just apply it
 - List human process steps (deploy, announce) — produce artifacts Claude can generate
+- Write publishing commands without checking `make release` first

--- a/hooks/ways/softwaredev/delivery/way.md
+++ b/hooks/ways/softwaredev/delivery/way.md
@@ -7,13 +7,15 @@ scope: agent, subagent
 ---
 # Delivery
 
+**Before ad-hoc commands, check `make help`.** If the project has a Makefile, it likely has `make release`, `make dist`, `make deploy`, or similar targets that encode the project's actual publishing workflow. Use those.
+
 Children of this way cover the journey from local changes to production:
 
 | Stage | Way |
 |-------|-----|
 | Commits, messages | `delivery/commits` |
 | PRs, review, merge | `delivery/github` |
-| Releases, tagging | `delivery/release` |
+| Releases, tagging, publishing | `delivery/release` |
 | Schema migrations | `delivery/migrations` |
 | Patch creation | `delivery/patches` |
 | Implementation planning | `delivery/implement` |


### PR DESCRIPTION
## Summary

- Release way now checks for `make release` / `make dist` before ad-hoc commands
- Added artifact publishing table (GitHub Releases, npm, PyPI, cargo, AUR, containers)
- Delivery parent reinforces "check `make help` first" pattern
- Multi-platform binary guidance (per our way-embed/mmaid pattern)

## Test plan

- [x] Lint clean
- [x] No changes to matching behavior (frontmatter unchanged)