### PR TITLE
feat(config): switch statusline to ccstatusline

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -188,7 +188,8 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "${HOME}/.claude/statusline.sh"
+    "command": "npx -y ccstatusline@latest",
+    "padding": 0
   },
   "enabledPlugins": {
     "clangd-lsp@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- Switches statusline to [ccstatusline](https://github.com/sirmalloc/ccstatusline)
- Personal config update reflecting my own usage of this Claude Code setup

## Test plan
- Visual inspection of status line in Claude Code sessions