### PR TITLE
feat(swc): build subagent workflow planning and execution skill suite

### DIFF
--- a/hooks/ways/meta/authoring-check/way.md
+++ b/hooks/ways/meta/authoring-check/way.md
@@ -1,0 +1,23 @@
+---
+files: way\.md$|SKILL\.md$|\.claude/hooks/[^/]+\.sh$
+scope: agent, subagent
+---
+# Before Creating a New Way, Skill, or Hook
+
+Check whether something already exists that covers this need before writing new content.
+
+## Steps
+
+1. **Ways** — scan `~/.claude/hooks/ways/` and `$PROJECT/.claude/ways/` for existing ways with overlapping vocabulary or file triggers
+2. **Skills** — scan `~/.claude/skills/` and `.claude/skills/` for existing skills with similar descriptions
+3. **Hooks** — check `~/.claude/hooks/` and `settings.json` for existing hook scripts that already intercept the same event
+
+## Decision
+
+| Finding | Action |
+|---------|--------|
+| Existing coverage, partial gap | Extend the existing file |
+| Overlapping but different concern | Create new, ensure vocabulary doesn't collide |
+| Nothing relevant | Proceed with new |
+
+Present the finding to the user before writing anything.


### PR DESCRIPTION
## Summary
- Adds a new `meta/authoring-check` way that fires when editing `way.md`, `SKILL.md`, or hook `.sh` files
- Reminds Claude to check for existing coverage before creating new ways, skills, or hooks
- Surfaces findings to the user before writing anything new

## Test plan
- Edit a `way.md` file and confirm the authoring-check guidance is injected
- Edit a `SKILL.md` file and confirm the same