### PR TITLE
fix(ways): follow symlinks in way discovery

### DIFF
--- a/hooks/ways/check-bash-pre.sh
+++ b/hooks/ways/check-bash-pre.sh
@@ -68,7 +68,7 @@ scan_ways() {
     if [[ -n "$DESC" && -n "$pattern" && "$DESC" =~ $pattern ]]; then
       CONTEXT+=$(~/.claude/hooks/ways/show-way.sh "$waypath" "$SESSION_ID" "bash")
     fi
-  done < <(find "$dir" -name "way.md" -print0 2>/dev/null)
+  done < <(find -L "$dir" -name "way.md" -print0 2>/dev/null)
 }
 
 # Scan project-local first, then global
@@ -129,7 +129,7 @@ scan_checks() {
       check_out=$("${HOME}/.claude/hooks/ways/show-check.sh" "$waypath" "$SESSION_ID" "bash" "$MATCH_SCORE")
       [[ -n "$check_out" ]] && CONTEXT+="$check_out"
     fi
-  done < <(find "$dir" -name "check.md" -print0 2>/dev/null)
+  done < <(find -L "$dir" -name "check.md" -print0 2>/dev/null)
 }
 
 scan_checks "$PROJECT_DIR/.claude/ways"

--- a/hooks/ways/check-file-pre.sh
+++ b/hooks/ways/check-file-pre.sh
@@ -60,7 +60,7 @@ scan_ways() {
     if [[ -n "$files" && "$FP" =~ $files ]]; then
       CONTEXT+=$(~/.claude/hooks/ways/show-way.sh "$waypath" "$SESSION_ID" "file")
     fi
-  done < <(find "$dir" -name "way.md" -print0 2>/dev/null)
+  done < <(find -L "$dir" -name "way.md" -print0 2>/dev/null)
 }
 
 # Scan project-local first, then global
@@ -129,7 +129,7 @@ scan_checks() {
       check_out=$("${HOME}/.claude/hooks/ways/show-check.sh" "$waypath" "$SESSION_ID" "file" "$MATCH_SCORE")
       [[ -n "$check_out" ]] && CONTEXT+="$check_out"
     fi
-  done < <(find "$dir" -name "check.md" -print0 2>/dev/null)
+  done < <(find -L "$dir" -name "check.md" -print0 2>/dev/null)
 }
 
 scan_checks "$PROJECT_DIR/.claude/ways"

--- a/hooks/ways/check-prompt.sh
+++ b/hooks/ways/check-prompt.sh
@@ -93,7 +93,7 @@ scan_ways() {
     if match_way_prompt "$PROMPT" "$pattern" "$description" "$vocabulary" "$effective_threshold" "$waypath"; then
       ~/.claude/hooks/ways/show-way.sh "$waypath" "$SESSION_ID" "${MATCH_CHANNEL:-prompt}"
     fi
-  done < <(find "$dir" -name "way.md" -print0 2>/dev/null)
+  done < <(find -L "$dir" -name "way.md" -print0 2>/dev/null)
 }
 
 # Scan project-local first, then global

--- a/hooks/ways/check-smart-trigger.sh
+++ b/hooks/ways/check-smart-trigger.sh
@@ -69,7 +69,7 @@ collect_candidates() {
         CANDIDATE_DESC["$waypath"]="${heading:-$waypath}"
       fi
     fi
-  done < <(find "$dir" -name "way.md" -print0 2>/dev/null)
+  done < <(find -L "$dir" -name "way.md" -print0 2>/dev/null)
 }
 
 # Collect from project-local and global

--- a/hooks/ways/check-state.sh
+++ b/hooks/ways/check-state.sh
@@ -168,7 +168,7 @@ scan_state_triggers() {
       esac
     fi
 
-  done < <(find "$dir" -name "way.md" -print0 2>/dev/null)
+  done < <(find -L "$dir" -name "way.md" -print0 2>/dev/null)
 }
 
 # Safety net: re-inject core if context was cleared without SessionStart

--- a/hooks/ways/check-task-pre.sh
+++ b/hooks/ways/check-task-pre.sh
@@ -74,7 +74,7 @@ scan_ways_for_subagent() {
     if match_way_prompt "$TASK_PROMPT" "$pattern" "$description" "$vocabulary" "$threshold" "$waypath"; then
       MATCHED_WAYS+=("$waypath|${MATCH_CHANNEL:-prompt}")
     fi
-  done < <(find "$dir" -name "way.md" -print0 2>/dev/null)
+  done < <(find -L "$dir" -name "way.md" -print0 2>/dev/null)
 }
 
 # Scan project-local first, then global

--- a/hooks/ways/embed-lib.sh
+++ b/hooks/ways/embed-lib.sh
@@ -14,9 +14,9 @@
 content_hash() {
   local dir="$1"
   if command -v sha256sum &>/dev/null; then
-    find "$dir" -name "way.md" -type f -exec sha256sum {} + 2>/dev/null | sort | sha256sum | cut -d' ' -f1
+    find -L "$dir" -name "way.md" -type f -exec sha256sum {} + 2>/dev/null | sort | sha256sum | cut -d' ' -f1
   elif command -v shasum &>/dev/null; then
-    find "$dir" -name "way.md" -type f -exec shasum -a 256 {} + 2>/dev/null | sort | shasum -a 256 | cut -d' ' -f1
+    find -L "$dir" -name "way.md" -type f -exec shasum -a 256 {} + 2>/dev/null | sort | shasum -a 256 | cut -d' ' -f1
   else
     echo "no-hash-tool"
   fi
@@ -172,7 +172,7 @@ enumerate_projects() {
 "
 
     local way_count
-    way_count=$(find "$ways_dir" -name "way.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+    way_count=$(find -L "$ways_dir" -name "way.md" -type f 2>/dev/null | wc -l | tr -d ' ')
     [[ $way_count -eq 0 ]] && continue
 
     # Count semantic ways (have both description and vocabulary)
@@ -183,7 +183,7 @@ enumerate_projects() {
       if echo "$fm" | grep -q '^description:' && echo "$fm" | grep -q '^vocabulary:'; then
         sem_count=$((sem_count + 1))
       fi
-    done < <(find "$ways_dir" -name "way.md" -type f 2>/dev/null)
+    done < <(find -L "$ways_dir" -name "way.md" -type f 2>/dev/null)
 
     echo "${encoded}|${project_path}|${way_count}|${sem_count}"
   done < <(find "$projects_dir" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)

--- a/hooks/ways/embed-status.sh
+++ b/hooks/ways/embed-status.sh
@@ -95,12 +95,12 @@ if [[ "$ENGINE" == "auto" ]]; then
 fi
 
 # --- Global ways ---
-GLOBAL_WAY_COUNT=$(find "$WAYS_DIR" -name "way.md" -type f 2>/dev/null | wc -l)
+GLOBAL_WAY_COUNT=$(find -L "$WAYS_DIR" -name "way.md" -type f 2>/dev/null | wc -l)
 SEMANTIC_WAY_COUNT=0
 while IFS= read -r wf; do
   fm=$(awk 'NR==1 && /^---$/{p=1;next} p && /^---$/{exit} p{print}' "$wf")
   echo "$fm" | grep -q '^description:' && echo "$fm" | grep -q '^vocabulary:' && SEMANTIC_WAY_COUNT=$((SEMANTIC_WAY_COUNT + 1))
-done < <(find "$WAYS_DIR" -name "way.md" -type f 2>/dev/null)
+done < <(find -L "$WAYS_DIR" -name "way.md" -type f 2>/dev/null)
 
 # --- Shared library ---
 EMBED_LIB="${HOME}/.claude/hooks/ways/embed-lib.sh"

--- a/hooks/ways/lint-ways.sh
+++ b/hooks/ways/lint-ways.sh
@@ -373,7 +373,7 @@ scan_dir() {
         [[ "$f" == *check.md ]] && ftype="check"
         lint_file "$f" "$ftype"
         ((count++))
-    done < <(find "$dir" \( -name "way.md" -o -name "check.md" \) -print0 2>/dev/null | sort -z)
+    done < <(find -L "$dir" \( -name "way.md" -o -name "check.md" \) -print0 2>/dev/null | sort -z)
 
     echo ""
     echo -e "${DIM}${label}: scanned $count files${RESET}"

--- a/hooks/ways/macro.sh
+++ b/hooks/ways/macro.sh
@@ -118,7 +118,7 @@ while IFS= read -r wayfile; do
 
   echo "| **${wayname}** | ${tool_trigger} | ${keyword_display} |"
 
-done < <(find "$WAYS_DIR" -path "*/*/way.md" -type f | sort)
+done < <(find -L "$WAYS_DIR" -path "*/*/way.md" -type f | sort)
 
 echo ""
 echo "Project-local ways: \`\$PROJECT/.claude/ways/{domain}/{way}/way.md\` override global."

--- a/hooks/ways/meta/knowledge/optimization/macro.sh
+++ b/hooks/ways/meta/knowledge/optimization/macro.sh
@@ -14,7 +14,7 @@ echo ""
 printf "%-35s %6s %6s %6s %s\n" "Way" "Gaps" "Cover" "Unused" "Match"
 printf "%-35s %6s %6s %6s %s\n" "---" "----" "-----" "------" "-----"
 
-for wayfile in $(find "${HOME}/.claude/hooks/ways" -name "way.md" -print 2>/dev/null | sort); do
+for wayfile in $(find -L "${HOME}/.claude/hooks/ways" -name "way.md" -print 2>/dev/null | sort); do
   relpath="${wayfile#${HOME}/.claude/hooks/ways/}"
   relpath="${relpath%/way.md}"
 
@@ -48,7 +48,7 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
 if [[ -n "$PROJECT_DIR" && -d "$PROJECT_DIR/.claude/ways" ]]; then
   echo ""
   echo "### Project-local ways"
-  for wayfile in $(find "$PROJECT_DIR/.claude/ways" -name "way.md" -print 2>/dev/null | sort); do
+  for wayfile in $(find -L "$PROJECT_DIR/.claude/ways" -name "way.md" -print 2>/dev/null | sort); do
     relpath="${wayfile#$PROJECT_DIR/.claude/ways/}"
     relpath="${relpath%/way.md}"
     printf "%-35s %s\n" "$relpath" "(project-local)"

--- a/tools/way-match/generate-corpus.sh
+++ b/tools/way-match/generate-corpus.sh
@@ -91,7 +91,7 @@ scan_ways_dir() {
 
     count=$((count + 1))
 
-  done < <(find "$scan_dir" -name "way.md" -type f | sort)
+  done < <(find -L "$scan_dir" -name "way.md" -type f | sort)
 
   # Also scan for way-*.md (future locale files)
   while IFS= read -r wayfile; do
@@ -116,7 +116,7 @@ scan_ways_dir() {
 
     count=$((count + 1))
 
-  done < <(find "$scan_dir" -name "way-*.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$scan_dir" -name "way-*.md" -type f 2>/dev/null | sort)
 }
 
 # resolve_project_path provided by embed-lib.sh
@@ -137,7 +137,7 @@ check_ways_embed_marker() {
     if echo "$fm" | grep -q '^description:' && echo "$fm" | grep -q '^vocabulary:'; then
       semantic_count=$((semantic_count + 1))
     fi
-  done < <(find "$ways_dir" -name "way.md" -type f 2>/dev/null)
+  done < <(find -L "$ways_dir" -name "way.md" -type f 2>/dev/null)
 
   if [[ -f "$marker" ]]; then
     local state

--- a/tools/way-match/test-integration.sh
+++ b/tools/way-match/test-integration.sh
@@ -58,7 +58,7 @@ while IFS= read -r wayfile; do
   WAY_PATHS+=("$wayfile")
 
   printf "  %-30s thresh=%-5s  %s\n" "$way_id" "${thresh:-2.0}" "$(echo "$desc" | cut -c1-60)"
-done < <(find "$WAYS_DIR" -name "way.md" -type f | sort)
+done < <(find -L "$WAYS_DIR" -name "way.md" -type f | sort)
 
 echo ""
 echo "Found ${#WAY_IDS[@]} semantic ways"

--- a/tools/way-tree-analyze.sh
+++ b/tools/way-tree-analyze.sh
@@ -130,7 +130,7 @@ cmd_tree() {
     tokens=$(estimate_tokens "$wayfile")
     vocabcount=$(echo "$vocab" | wc -w)
     echo "NODE	${depth}	${rel}	${threshold:-none}	${type}	${vocabcount}	${tokens}"
-  done < <(find "$tree_path" -name 'way.md' -o -name 'check.md' | sort)
+  done < <(find -L "$tree_path" -name 'way.md' -o -name 'check.md' | sort)
 }
 
 # === budget command ===
@@ -146,7 +146,7 @@ cmd_budget() {
     rel=$(relpath "$wayfile")
     tokens=$(estimate_tokens "$wayfile")
     echo "WAY	${rel}	${tokens}"
-  done < <(find "$tree_path" -name 'way.md' -o -name 'check.md' | sort)
+  done < <(find -L "$tree_path" -name 'way.md' -o -name 'check.md' | sort)
 
   # Path costs (root to each leaf)
   local root_tokens=0
@@ -179,7 +179,7 @@ cmd_budget() {
     done
 
     echo "PATH	$(relpath "$dir")	${path_tokens}"
-  done < <(find "$tree_path" -name 'way.md' | sort)
+  done < <(find -L "$tree_path" -name 'way.md' | sort)
 }
 
 # === jaccard command ===
@@ -196,7 +196,7 @@ cmd_jaccard() {
     dir=$(dirname "$wayfile")
     parent=$(dirname "$dir")
     parent_children["$parent"]+="${wayfile}"$'\n'
-  done < <(find "$tree_path" -name 'way.md' | sort)
+  done < <(find -L "$tree_path" -name 'way.md' | sort)
 
   # For each parent, compute pairwise Jaccard of children's vocabularies
   for parent in "${!parent_children[@]}"; do


### PR DESCRIPTION
Fixes #77

## Problem
`find "$scan_dir" -name "way.md" -type f` does not traverse symlinked directories, making ways inherited via symlinks (e.g. submodule way directories symlinked into `.claude/ways/`) invisible to all discovery paths.

## Fix
Added `-L` flag to every `find` command that discovers `way.md` or `check.md` files across the ways tooling.

## Affected files
- `tools/way-match/generate-corpus.sh` (3 finds: lines 94, 119, 140)
- `tools/way-match/test-integration.sh` (line 61)
- `tools/way-tree-analyze.sh` (4 finds: lines 133, 149, 182, 199)
- `hooks/ways/check-smart-trigger.sh` (line 72)
- `hooks/ways/check-state.sh` (line 171)
- `hooks/ways/check-bash-pre.sh` (2 finds: lines 71, 132)
- `hooks/ways/check-file-pre.sh` (2 finds: lines 63, 132)
- `hooks/ways/check-prompt.sh` (line 96)
- `hooks/ways/check-task-pre.sh` (line 77)
- `hooks/ways/macro.sh` (line 121)
- `hooks/ways/embed-status.sh` (2 finds: lines 98, 103)
- `hooks/ways/embed-lib.sh` (4 finds: lines 17, 19, 175, 186)
- `hooks/ways/lint-ways.sh` (line 376)
- `hooks/ways/meta/knowledge/optimization/macro.sh` (2 finds: lines 17, 51)