### PR TITLE
fix(ways-cli): embed-exclusive semantic matching, consolidate scan task

### DIFF
--- a/hooks/ways/check-task-pre.sh
+++ b/hooks/ways/check-task-pre.sh
@@ -1,129 +1,22 @@
 #!/bin/bash
-# PreToolUse:Task - Stash subagent-scoped ways for SubagentStart
-#
-# TRIGGER FLOW:
-# ┌─────────────────┐     ┌──────────────────┐     ┌───────────────┐
-# │ PreToolUse:Task │────▶│ scan_ways()      │────▶│ write stash   │
-# │ (hook event)    │     │ scope: subagent  │     │ for injection │
-# └─────────────────┘     └──────────────────┘     └───────────────┘
+# PreToolUse:Task — thin dispatcher to ways binary
 #
 # Phase 1 of two-phase subagent injection:
-# 1. PreToolUse:Task scans Task prompt against ways with subagent scope
-# 2. SubagentStart (inject-subagent.sh) reads stash and emits content
-#
-# Stash: {SESSIONS_ROOT}/{session_id}/subagent-stash/{timestamp}.json
+# 1. This script: ways scan task (matches ways, writes stash)
+# 2. SubagentStart: inject-subagent.sh (reads stash, emits content)
 
 INPUT=$(cat)
 TASK_PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty' | tr '[:upper:]' '[:lower:]')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(echo "$INPUT" | jq -r '.cwd // empty')}"
-WAYS_DIR="${HOME}/.claude/hooks/ways"
-
-# Ways binary for matching
-WAYS_BIN="${HOME}/.claude/bin/ways"
-
-# File discovery (inline)
-find_way_files() {
-  local dir="$1"
-  find -L "$dir" -name "*.md" ! -name "*.check.md" -print0 2>/dev/null | while IFS= read -r -d '' f; do
-    head -1 "$f" 2>/dev/null | grep -q '^---$' && printf '%s\0' "$f"
-  done
-}
-way_id_from_path() {
-  local filepath="$1" basedir="$2"
-  local rel="${filepath#$basedir/}"
-  echo "${rel%/*}"
-}
-
-# BM25 batch cache (one call scores all)
-BM25_CACHE=""
-_get_bm25_cache() {
-  if [[ -z "$BM25_CACHE" && -x "$WAYS_BIN" ]]; then
-    BM25_CACHE=$("$WAYS_BIN" match "$TASK_PROMPT" 2>/dev/null || true)
-  fi
-}
-# Simple prompt matching: pattern OR BM25
-match_way_prompt() {
-  local prompt="$1" pattern="$2" desc="$3" vocab="$4" threshold="$5" way_id="$6"
-  MATCH_CHANNEL=""
-  if [[ -n "$pattern" && "$prompt" =~ $pattern ]]; then
-    MATCH_CHANNEL="keyword"; return 0
-  fi
-  _get_bm25_cache
-  if [[ -n "$BM25_CACHE" ]] && echo "$BM25_CACHE" | grep -qF "${way_id}	"; then
-    MATCH_CHANNEL="semantic:bm25"; return 0
-  fi
-  return 1
-}
-
-# Detect teammate spawn (Task tool with team_name parameter)
 TEAM_NAME=$(echo "$INPUT" | jq -r '.tool_input.team_name // empty')
-IS_TEAMMATE=false
-[[ -n "$TEAM_NAME" ]] && IS_TEAMMATE=true
 
-[[ -z "$TASK_PROMPT" ]] && exit 0
-[[ -z "$SESSION_ID" ]] && exit 0
+[[ -z "$TASK_PROMPT" || -z "$SESSION_ID" ]] && exit 0
 
-source "$(dirname "$0")/sessions-root.sh"
-STASH_DIR="${SESSIONS_ROOT}/${SESSION_ID}/subagent-stash"
-mkdir -p "$STASH_DIR"
+ARGS=(--query "$TASK_PROMPT" --session "$SESSION_ID" --project "$PROJECT_DIR")
+[[ -n "$TEAM_NAME" ]] && ARGS+=(--team "$TEAM_NAME")
 
-MATCHED_WAYS=()
-
-scan_ways_for_subagent() {
-  local dir="$1"
-  [[ ! -d "$dir" ]] && return
-
-  while IFS= read -r -d '' wayfile; do
-    waypath="${wayfile#$dir/}"
-    waypath="$(way_id_from_path "$wayfile" "$dir")"
-
-    # Extract frontmatter
-    frontmatter=$(awk 'NR==1 && /^---$/{p=1; next} p && /^---$/{exit} p{print}' "$wayfile")
-    get_field() { echo "$frontmatter" | awk "/^$1:/"'{gsub(/^'"$1"': */, ""); print; exit}'; }
-
-    # Must have subagent or teammate scope
-    local scope_raw=$(get_field "scope")
-    scope_raw="${scope_raw:-agent}"
-    if $IS_TEAMMATE; then
-      # Teammates match ways with scope: teammate OR subagent
-      echo "$scope_raw" | grep -qwE "subagent|teammate" || continue
-    else
-      echo "$scope_raw" | grep -qw "subagent" || continue
-    fi
-
-    # Skip state-triggered ways (they don't match on content)
-    local trigger=$(get_field "trigger")
-    [[ -n "$trigger" ]] && continue
-
-    # Additive matching: pattern OR semantic (shared with check-prompt.sh)
-    local pattern=$(get_field "pattern")
-    local description=$(get_field "description")
-    local vocabulary=$(get_field "vocabulary")
-    local threshold=$(get_field "threshold")
-
-    if match_way_prompt "$TASK_PROMPT" "$pattern" "$description" "$vocabulary" "$threshold" "$waypath"; then
-      MATCHED_WAYS+=("$waypath|${MATCH_CHANNEL:-prompt}")
-    fi
-  done < <(find_way_files "$dir")
-}
-
-# Scan project-local first, then global
-scan_ways_for_subagent "$PROJECT_DIR/.claude/ways"
-scan_ways_for_subagent "${WAYS_DIR}"
-
-# Write stash if any ways matched
-if [[ ${#MATCHED_WAYS[@]} -gt 0 ]]; then
-  TIMESTAMP=$(date +%s%N)
-  STASH_FILE="${STASH_DIR}/${TIMESTAMP}.json"
-
-  # Each entry is "waypath|channel" — split into parallel arrays
-  WAYS_JSON=$(printf '%s\n' "${MATCHED_WAYS[@]}" | cut -d'|' -f1 | jq -R . | jq -s .)
-  CHANNELS_JSON=$(printf '%s\n' "${MATCHED_WAYS[@]}" | cut -d'|' -f2 | jq -R . | jq -s .)
-  jq -n --argjson ways "$WAYS_JSON" --argjson channels "$CHANNELS_JSON" \
-    --argjson teammate "$IS_TEAMMATE" --arg team "$TEAM_NAME" \
-    '{ways: $ways, channels: $channels, is_teammate: $teammate, team_name: $team}' > "$STASH_FILE"
-fi
+"${HOME}/.claude/bin/ways" scan task "${ARGS[@]}"
 
 # Never block Task creation
 exit 0

--- a/tools/ways-cli/src/cmd/scan/mod.rs
+++ b/tools/ways-cli/src/cmd/scan/mod.rs
@@ -47,9 +47,13 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
     let scope = session::detect_scope(session_id);
     let candidates = collect_candidates(&project_dir);
 
-    // Batch semantic scoring
-    let bm25_matches = batch_bm25_score(query);
+    // Batch semantic scoring — embed is authoritative when available
     let embed_matches = batch_embed_score(query);
+    let bm25_matches = if embed_matches.is_some() {
+        Vec::new() // embedding engine is healthy — skip BM25 entirely
+    } else {
+        batch_bm25_score(query)
+    };
 
     for way in &candidates {
         if !session::scope_matches(&way.scope, &scope) {
@@ -69,12 +73,102 @@ pub fn prompt(query: &str, session_id: &str, project: Option<&str>) -> Result<()
             &way.id,
             effective_threshold,
             &bm25_matches,
-            &embed_matches,
+            embed_matches.as_deref(),
         );
 
         if let Some(trigger) = channel {
             let _ = crate::cmd::show::way(&way.id, session_id, &trigger);
         }
+    }
+
+    Ok(())
+}
+
+// ── Task scan (subagent/teammate stash) ────────────────────────
+
+pub fn task(
+    query: &str,
+    session_id: &str,
+    project: Option<&str>,
+    team: Option<&str>,
+) -> Result<()> {
+    let project_dir = project
+        .map(|s| s.to_string())
+        .unwrap_or_else(default_project);
+
+    let is_teammate = team.is_some();
+    let candidates = collect_candidates(&project_dir);
+
+    // Batch semantic scoring — embed exclusive when available
+    let embed_matches = batch_embed_score(query);
+    let bm25_matches = if embed_matches.is_some() {
+        Vec::new()
+    } else {
+        batch_bm25_score(query)
+    };
+
+    let mut matched: Vec<(String, String)> = Vec::new(); // (way_id, channel)
+
+    for way in &candidates {
+        // Must have subagent or teammate scope
+        let scope = &way.scope;
+        if is_teammate {
+            if !scope.contains("subagent") && !scope.contains("teammate") {
+                continue;
+            }
+        } else {
+            if !scope.contains("subagent") {
+                continue;
+            }
+        }
+
+        // Skip state-triggered ways
+        if way.trigger.is_some() {
+            continue;
+        }
+
+        if !check_when(&way.when_project, &way.when_file_exists, &project_dir) {
+            continue;
+        }
+
+        let channel = match_prompt(
+            query,
+            &way.pattern,
+            &way.id,
+            way.threshold,
+            &bm25_matches,
+            embed_matches.as_deref(),
+        );
+
+        if let Some(trigger) = channel {
+            matched.push((way.id.clone(), trigger));
+        }
+    }
+
+    // Write stash file if any ways matched
+    if !matched.is_empty() {
+        let stash_dir = format!(
+            "{}/{session_id}/subagent-stash",
+            session::sessions_root()
+        );
+        std::fs::create_dir_all(&stash_dir)?;
+
+        let ways: Vec<&str> = matched.iter().map(|(id, _)| id.as_str()).collect();
+        let channels: Vec<&str> = matched.iter().map(|(_, ch)| ch.as_str()).collect();
+
+        let stash = serde_json::json!({
+            "ways": ways,
+            "channels": channels,
+            "is_teammate": is_teammate,
+            "team_name": team.unwrap_or(""),
+        });
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let stash_file = format!("{stash_dir}/{timestamp}.json");
+        std::fs::write(&stash_file, stash.to_string())?;
     }
 
     Ok(())
@@ -141,8 +235,14 @@ pub fn command(
         description.unwrap_or("")
     );
 
-    // Batch BM25 for check scoring
-    let bm25_matches = batch_bm25_score(&query_for_checks);
+    // Semantic scoring for checks — embed exclusive when available
+    let embed_check_matches = batch_embed_score(&query_for_checks);
+    let bm25_check_matches = if embed_check_matches.is_some() {
+        Vec::new()
+    } else {
+        batch_bm25_score(&query_for_checks)
+    };
+    let semantic_matches = embed_check_matches.as_deref().unwrap_or(&bm25_check_matches);
 
     for check in &checks {
         if !session::scope_matches(&check.scope, &scope) {
@@ -161,7 +261,7 @@ pub fn command(
         }
 
         if match_score == 0.0 && !check.description.is_empty() && !check.vocabulary.is_empty() {
-            if let Some(score) = bm25_matches.iter().find(|(id, _)| *id == check.id).map(|(_, s)| *s) {
+            if let Some(score) = semantic_matches.iter().find(|(id, _)| *id == check.id).map(|(_, s)| *s) {
                 if score > 0.0 {
                     match_score = score;
                 }
@@ -221,9 +321,15 @@ pub fn file(filepath: &str, session_id: &str, project: Option<&str>) -> Result<(
         }
     }
 
-    // Check matching for files
+    // Check matching for files — embed exclusive when available
     let checks = collect_checks(&project_dir);
-    let bm25_matches = batch_bm25_score(filepath);
+    let embed_matches = batch_embed_score(filepath);
+    let bm25_matches = if embed_matches.is_some() {
+        Vec::new()
+    } else {
+        batch_bm25_score(filepath)
+    };
+    let semantic_matches = embed_matches.as_deref().unwrap_or(&bm25_matches);
 
     for check in &checks {
         if !session::scope_matches(&check.scope, &scope) {
@@ -242,7 +348,7 @@ pub fn file(filepath: &str, session_id: &str, project: Option<&str>) -> Result<(
         }
 
         if match_score == 0.0 && !check.description.is_empty() && !check.vocabulary.is_empty() {
-            if let Some(score) = bm25_matches.iter().find(|(id, _)| *id == check.id).map(|(_, s)| *s) {
+            if let Some(score) = semantic_matches.iter().find(|(id, _)| *id == check.id).map(|(_, s)| *s) {
                 if score > 0.0 {
                     match_score = score;
                 }
@@ -278,7 +384,7 @@ fn match_prompt(
     way_id: &str,
     threshold: f64,
     bm25: &[(String, f64)],
-    embed: &[(String, f64)],
+    embed: Option<&[(String, f64)]>,
 ) -> Option<String> {
     // Channel 1: Regex pattern — always checked first
     if let Some(ref pat) = pattern {
@@ -287,18 +393,17 @@ fn match_prompt(
         }
     }
 
-    // Channel 2: Embedding — primary semantic engine when available.
-    // If embed returned ANY results (engine is working), it's authoritative.
-    // Only fall through to BM25 when embed returned nothing (engine unavailable).
-    if !embed.is_empty() {
-        if embed.iter().any(|(id, _)| id == way_id) {
+    // Channel 2: Embedding — exclusive when engine is available.
+    // Some(matches) means engine ran (even if empty) — BM25 is suppressed.
+    // None means engine is unavailable — fall through to BM25.
+    if let Some(embed_results) = embed {
+        if embed_results.iter().any(|(id, _)| id == way_id) {
             return Some("semantic:embedding".to_string());
         }
-        // Embed is working but didn't match this way — don't fall through to BM25
         return None;
     }
 
-    // Channel 3: BM25 — fallback when embedding engine is unavailable
+    // Channel 3: BM25 — only when embedding engine is unavailable
     if let Some((_, score)) = bm25.iter().find(|(id, _)| id == way_id) {
         if *score >= threshold {
             return Some("semantic:bm25".to_string());

--- a/tools/ways-cli/src/cmd/scan/scoring.rs
+++ b/tools/ways-cli/src/cmd/scan/scoring.rs
@@ -35,10 +35,15 @@ pub(crate) fn batch_bm25_score(query: &str) -> Vec<(String, f64)> {
         .collect()
 }
 
-pub(crate) fn batch_embed_score(query: &str) -> Vec<(String, f64)> {
+/// Returns `Some(matches)` when the embedding engine ran successfully
+/// (even if no ways matched), or `None` when the engine is unavailable.
+/// This distinction matters: `Some(vec![])` means "engine is healthy,
+/// nothing matched" — BM25 should NOT fire. `None` means "engine is
+/// down" — BM25 fallback is appropriate.
+pub(crate) fn batch_embed_score(query: &str) -> Option<Vec<(String, f64)>> {
     let ways_bin = home_dir().join(".claude/bin/ways");
     if !ways_bin.is_file() {
-        return Vec::new();
+        return None;
     }
 
     let output = std::process::Command::new(&ways_bin)
@@ -47,17 +52,19 @@ pub(crate) fn batch_embed_score(query: &str) -> Vec<(String, f64)> {
 
     match output {
         Ok(o) if o.status.success() => {
-            String::from_utf8_lossy(&o.stdout)
-                .lines()
-                .filter_map(|line| {
-                    let mut parts = line.split('\t');
-                    let id = parts.next()?.to_string();
-                    let score: f64 = parts.next()?.parse().ok()?;
-                    Some((id, score))
-                })
-                .collect()
+            Some(
+                String::from_utf8_lossy(&o.stdout)
+                    .lines()
+                    .filter_map(|line| {
+                        let mut parts = line.split('\t');
+                        let id = parts.next()?.to_string();
+                        let score: f64 = parts.next()?.parse().ok()?;
+                        Some((id, score))
+                    })
+                    .collect(),
+            )
         }
-        _ => Vec::new(),
+        _ => None,
     }
 }
 

--- a/tools/ways-cli/src/main.rs
+++ b/tools/ways-cli/src/main.rs
@@ -240,6 +240,21 @@ enum ScanCommand {
         #[arg(long)]
         project: Option<String>,
     },
+    /// Scan ways for subagent/teammate injection (writes stash for SubagentStart)
+    Task {
+        /// Task prompt text (lowercase)
+        #[arg(long)]
+        query: String,
+        /// Session ID
+        #[arg(long)]
+        session: String,
+        /// Project directory
+        #[arg(long)]
+        project: Option<String>,
+        /// Team name (if teammate spawn)
+        #[arg(long)]
+        team: Option<String>,
+    },
     /// Evaluate state-based triggers (context-threshold, file-exists, session-start)
     State {
         /// Session ID
@@ -354,6 +369,9 @@ fn main() -> Result<()> {
             }
             ScanCommand::File { path, session, project } => {
                 cmd::scan::file(&path, &session, project.as_deref())
+            }
+            ScanCommand::Task { query, session, project, team } => {
+                cmd::scan::task(&query, &session, project.as_deref(), team.as_deref())
             }
             ScanCommand::State { session, project, transcript } => {
                 cmd::scan::state(&session, project.as_deref(), transcript.as_deref())


### PR DESCRIPTION
## Summary

- **BM25 false positives on short prompts** — when embedding returned zero results for prompts like "ok", the empty vec was indistinguishable from "engine unavailable," causing BM25 fallback to fire on response-topic context and produce false matches (e.g., `meta/trust/voice` firing on "trace through hooks")
- **Fix**: `batch_embed_score` returns `Option<Vec>` — `None` = engine down (BM25 fallback), `Some(vec![])` = engine ran, nothing matched (BM25 suppressed)
- **Applied to all 4 scan paths**: prompt, task, command checks, file checks
- **Consolidated `check-task-pre.sh`** from 130 lines of inline matching (file walking, frontmatter parsing, scope filtering, BM25 caching) into a new `ways scan task` subcommand + 20-line thin dispatcher — matching all other `check-*.sh` scripts

## Test plan

- [x] `make test` — lint, match, graph smoke tests pass
- [x] `make test-sim` — 10 simulation scenarios pass
- [x] Manual: `ways scan task --query "review code for quality" --session test` writes correct stash with `semantic:embedding` channels (no BM25 leakage)
- [x] Manual: `ways embed "ok"` returns 0 results — BM25 no longer fires as fallback
- [ ] Live session: verify `ways list` shows no `semantic:bm25` entries when embedding is healthy