### PR TITLE
fix: graceful degradation when ways binary is not installed

### DIFF
--- a/hooks/ways/check-bash-pre.sh
+++ b/hooks/ways/check-bash-pre.sh
@@ -4,6 +4,8 @@
 # The ways binary handles: command pattern matching, semantic scoring,
 # check curve scoring, session state, and content output.
 
+source "$(dirname "$0")/require-ways.sh"
+
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 DESC=$(echo "$INPUT" | jq -r '.tool_input.description // empty' | tr '[:upper:]' '[:lower:]')

--- a/hooks/ways/check-file-pre.sh
+++ b/hooks/ways/check-file-pre.sh
@@ -4,6 +4,8 @@
 # The ways binary handles: file pattern matching, check scoring,
 # session state, and content output.
 
+source "$(dirname "$0")/require-ways.sh"
+
 INPUT=$(cat)
 FP=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')

--- a/hooks/ways/check-prompt.sh
+++ b/hooks/ways/check-prompt.sh
@@ -5,6 +5,8 @@
 # + semantic matching, scope/precondition gating, parent threshold
 # lowering, session markers, macro dispatch, and content output.
 
+source "$(dirname "$0")/require-ways.sh"
+
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' | tr '[:upper:]' '[:lower:]')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')

--- a/hooks/ways/check-setup.sh
+++ b/hooks/ways/check-setup.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# SessionStart: Check if ways installation is complete.
+# Runs as the first startup hook. If setup is incomplete, emits a
+# one-time diagnostic and exits cleanly so other hooks don't error.
+#
+# Checks: ways binary → embedding model (optional) → corpus
+
+WAYS_BIN="${HOME}/.claude/bin/ways"
+XDG_WAY="${XDG_CACHE_HOME:-$HOME/.cache}/claude-ways/user"
+
+# Nothing to check if this isn't a ways-enabled install
+[[ ! -d "${HOME}/.claude/hooks/ways" ]] && exit 0
+
+if [[ ! -x "$WAYS_BIN" ]]; then
+  cat <<'MSG'
+
+⚠️  Ways setup incomplete — the `ways` binary is not installed.
+
+Hooks will be inactive until setup completes. Run:
+
+    cd ~/.claude && make setup
+
+This downloads the ways binary, embedding model, and generates
+the matching corpus. If you don't have a Rust toolchain, pre-built
+binaries are downloaded automatically.
+
+MSG
+  exit 0
+fi
+
+# Binary exists — check corpus
+CORPUS="${XDG_WAY}/ways-corpus.jsonl"
+if [[ ! -f "$CORPUS" ]]; then
+  cat <<'MSG'
+
+⚠️  Ways corpus not generated — semantic matching is inactive.
+
+Run:
+
+    cd ~/.claude && make setup
+
+MSG
+  exit 0
+fi
+
+# Optional: note if embedding model is missing (BM25 still works)
+MODEL="${XDG_WAY}/minilm-l6-v2.gguf"
+EMBED_BIN="${XDG_WAY}/way-embed"
+if [[ ! -f "$MODEL" ]] || [[ ! -x "$EMBED_BIN" ]]; then
+  # Only mention this once per day (rate limit via marker file)
+  MARKER="/tmp/.claude-embed-notice-$(date +%Y%m%d)"
+  if [[ ! -f "$MARKER" ]]; then
+    cat <<'MSG'
+
+ℹ️  Embedding model not installed — using BM25 fallback (91% vs 98% accuracy).
+
+To install the embedding engine:
+
+    cd ~/.claude && make setup
+
+MSG
+    touch "$MARKER" 2>/dev/null
+  fi
+fi

--- a/hooks/ways/check-state.sh
+++ b/hooks/ways/check-state.sh
@@ -4,6 +4,8 @@
 # Evaluates: context-threshold, file-exists, session-start triggers.
 # Also handles core guidance re-injection safety net.
 
+source "$(dirname "$0")/require-ways.sh"
+
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')

--- a/hooks/ways/check-task-pre.sh
+++ b/hooks/ways/check-task-pre.sh
@@ -5,6 +5,8 @@
 # 1. This script: ways scan task (matches ways, writes stash)
 # 2. SubagentStart: inject-subagent.sh (reads stash, emits content)
 
+source "$(dirname "$0")/require-ways.sh"
+
 INPUT=$(cat)
 TASK_PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty' | tr '[:upper:]' '[:lower:]')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')

--- a/hooks/ways/require-ways.sh
+++ b/hooks/ways/require-ways.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Guard: exit silently if ways binary is not available.
+# Source this at the top of any hook script that calls the ways binary.
+#
+# Usage: source "$(dirname "$0")/require-ways.sh"
+#
+# If the binary is missing, the script exits 0 (no error, no output).
+# The SessionStart check-setup.sh hook handles the user-facing diagnostic.
+
+WAYS_BIN="${HOME}/.claude/bin/ways"
+if [[ ! -x "$WAYS_BIN" ]]; then
+  exit 0
+fi

--- a/settings.json
+++ b/settings.json
@@ -53,6 +53,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${HOME}/.claude/hooks/ways/check-setup.sh"
+          },
+          {
+            "type": "command",
             "command": "${HOME}/.claude/hooks/ways/clear-markers.sh"
           },
           {


### PR DESCRIPTION
## Summary

- **check-setup.sh**: New SessionStart hook (runs first) that detects incomplete installs and emits clear fix instructions instead of letting every subsequent hook error out
- **require-ways.sh**: Shared guard sourced by all hook scripts that call the `ways` binary — exits 0 silently if binary is absent, preventing error spam
- Guards added to: check-prompt, check-bash-pre, check-file-pre, check-state, check-task-pre
- Embedding model notice rate-limited to once per day

Three states detected:
1. **Binary missing** → "run `make setup`" (hooks inactive)
2. **Corpus missing** → "run `make setup`" (matching inactive)
3. **Embedding model missing** → informational note (BM25 fallback active)

## Test plan

- [x] Binary missing: check-setup.sh emits diagnostic, exit 0
- [x] Binary missing: check-prompt.sh exits silently, exit 0 (no error)
- [x] Binary present: check-setup.sh silent, exit 0
- [x] All guards tested with renamed binary